### PR TITLE
docs: link v0.4.0 release from devlog footer

### DIFF
--- a/docs/devlog.jsx
+++ b/docs/devlog.jsx
@@ -113,6 +113,7 @@ function DevlogPage() {
         <div style={{ marginTop: 14, display: "flex", gap: 10, flexWrap: "wrap" }}>
           <a className="btn" href="https://discord.solarance-beginnings.com" target="_blank" rel="noopener">DISCORD →</a>
           <a className="btn ghost" href="#/community">PILOT'S LOUNGE</a>
+          <a className="btn ghost" href="https://github.com/GalaxyCr8r/solarance-beginnings/releases/tag/v0.4.0" target="_blank" rel="noopener">LATEST RELEASE: v0.4.0 →</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Adds a **LATEST RELEASE: v0.4.0 →** button to the devlog index page's subscribe/footer bracket in `docs/devlog.jsx`, alongside Discord and Pilot's Lounge. It opens the [v0.4.0 — M1: The Shared-Building Spike](https://github.com/GalaxyCr8r/solarance-beginnings/releases/tag/v0.4.0) release in a new tab.

## Context
Follows the `v0.4.0` release marking the completion of **M1 — Shared-Building Spike**. Once GitHub Pages rebuilds on merge, the release is reachable directly from the public devlog page.

## Notes
- The link/label is **static** — bump `v0.4.0` here each release (consistent with the manual `index.json` workflow). If you'd rather it never go stale, point the href at `…/releases/latest` (always redirects to newest) or wire it to the GitHub releases API like `app.jsx`'s BUILD badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)