### PR TITLE
Fix asteroid spawning: seed fields at init + hourly upkeep (#128)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,13 +797,17 @@ Get a DSL handle inside a reducer with `dsl(ctx)`:
 let dsl = dsl(ctx);
 ```
 
-For helper functions outside reducers, accept a generic `DSL<T>`:
+For helper functions called from reducers, type the `dsl` parameter as `&DSL<'_, ReducerContext>`:
 
 ```rust
-pub fn my_helper<T: spacetimedsl::WriteContext>(dsl: &DSL<T>) -> Result<(), String> {
+pub fn my_helper(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     // ...
 }
 ```
+
+**Never pass `ctx` alongside `dsl`.** `dsl` is a superset of `ctx` — reach the underlying `ReducerContext` via `dsl.ctx()` when you need `rng()`, `sender()`, or `timestamp`. A signature like `fn foo(ctx: &ReducerContext, dsl: &DSL<T>, ...)` is a sign that `dsl` was typed too generically; collapse to the concrete form above.
+
+Generic `&DSL<T>` (with a `T: spacetimedsl::WriteContext` bound) is reserved for helpers that must work across reducer *and* procedure contexts. This project has no procedures today, so prefer the concrete form for new helpers.
 
 ---
 
@@ -919,6 +923,6 @@ pub fn timer_update_all_ship_movement_controllers(
 2. **Pair `#[dsl(...)]` with every `#[table]`** — defines plural name and update method
 3. **Use `#[spacetimedb::reducer]`** (full path) — project convention
 4. **Use `dsl(ctx)` inside reducers** — not `ctx.db` directly
-5. **Pass `&DSL<T>` to helper functions** — use `T: spacetimedsl::WriteContext` bound
+5. **Type helper `dsl` params as `&DSL<'_, ReducerContext>`** — never pass `ctx` alongside `dsl`; reach the context via `dsl.ctx()`. Generic `&DSL<T>` is reserved for cross-reducer/procedure reuse.
 6. **Use generated CRUD methods** — don't call `ctx.db.*` for tables covered by DSL
 7. **Use ID wrappers** — `PlayerId::new(identity)`, not raw `Identity` where typed ID exists

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -9,6 +9,7 @@ use crate::{
         factions::FACTION_LRAK_COMBINE,
         item_types::{ITEM_IRON_ORE, ITEM_SILICON_ORE},
     },
+    logic::sectors::asteroid_fields::fill_asteroid_sector,
     logic::stations::{contribution::create_construction_site, *},
     logic::stellarobjects::stellar_object_creation::create_sobj,
     tables::{
@@ -21,8 +22,11 @@ use crate::{
 // Init
 //////////////////////////////////////////////////////////////
 
-pub fn init<T: spacetimedsl::WriteContext + 'static>(dsl: &DSL<T>) -> Result<(), String> {
-    demo_sectors(dsl)?;
+pub fn init<T: spacetimedsl::WriteContext + 'static>(
+    ctx: &ReducerContext,
+    dsl: &DSL<T>,
+) -> Result<(), String> {
+    demo_sectors(ctx, dsl)?;
 
     info!("Sectors Loaded: {}", dsl.get_all_sectors().count());
     Ok(())
@@ -32,13 +36,16 @@ pub fn init<T: spacetimedsl::WriteContext + 'static>(dsl: &DSL<T>) -> Result<(),
 // Utility
 //////////////////////////////////////////////////////////////
 
-fn demo_sectors<T: spacetimedsl::WriteContext + 'static>(dsl: &DSL<T>) -> Result<(), String> {
+fn demo_sectors<T: spacetimedsl::WriteContext + 'static>(
+    ctx: &ReducerContext,
+    dsl: &DSL<T>,
+) -> Result<(), String> {
     let faction_lrak = FactionId::new(FACTION_LRAK_COMBINE);
     let procyon = create_procyon_star_system(dsl, &faction_lrak)?;
     let (alpha, beta, gamma) = create_procyon_sectors(dsl, &procyon, &faction_lrak)?;
 
     setup_sector_connections(dsl, &alpha, &beta, &gamma)?;
-    populate_sectors_with_asteroids(dsl, &alpha, &beta)?;
+    populate_sectors_with_asteroids(ctx, dsl, &alpha, &beta)?;
     create_sector_stations(dsl, &alpha, &beta, &gamma, &faction_lrak)?;
     Ok(())
 }
@@ -173,26 +180,32 @@ fn setup_sector_connections<T: spacetimedsl::WriteContext>(
     Ok(())
 }
 
-/// Populates sectors with asteroid fields
-fn populate_sectors_with_asteroids<T: spacetimedsl::WriteContext>(
+/// Populates sectors with asteroid fields, then stocks each field to its full
+/// target population so asteroids exist from t=0. The hourly `sector_upkeep`
+/// timer only replenishes fields after they've been mined down.
+fn populate_sectors_with_asteroids<T: spacetimedsl::WriteContext + 'static>(
+    ctx: &ReducerContext,
     dsl: &DSL<T>,
     alpha: &Sector,
     beta: &Sector,
 ) -> Result<(), String> {
-    dsl.create_asteroid_sector(CreateAsteroidSector {
+    let alpha_field = dsl.create_asteroid_sector(CreateAsteroidSector {
         id: alpha.get_id(),
         sparseness: 1,
         rarity: 25,
         cluster_extent: 3000.0,
         cluster_inner: Some(1000.0),
     })?;
-    dsl.create_asteroid_sector(CreateAsteroidSector {
+    let beta_field = dsl.create_asteroid_sector(CreateAsteroidSector {
         id: beta.get_id(),
         sparseness: 5,
         rarity: 0,
         cluster_extent: 5000.0,
         cluster_inner: None,
     })?;
+
+    fill_asteroid_sector(ctx, dsl, &alpha_field)?;
+    fill_asteroid_sector(ctx, dsl, &beta_field)?;
 
     Ok(())
 }

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -22,11 +22,8 @@ use crate::{
 // Init
 //////////////////////////////////////////////////////////////
 
-pub fn init<T: spacetimedsl::WriteContext + 'static>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
-) -> Result<(), String> {
-    demo_sectors(ctx, dsl)?;
+pub fn init(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
+    demo_sectors(dsl)?;
 
     info!("Sectors Loaded: {}", dsl.get_all_sectors().count());
     Ok(())
@@ -36,23 +33,20 @@ pub fn init<T: spacetimedsl::WriteContext + 'static>(
 // Utility
 //////////////////////////////////////////////////////////////
 
-fn demo_sectors<T: spacetimedsl::WriteContext + 'static>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
-) -> Result<(), String> {
+fn demo_sectors(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     let faction_lrak = FactionId::new(FACTION_LRAK_COMBINE);
     let procyon = create_procyon_star_system(dsl, &faction_lrak)?;
     let (alpha, beta, gamma) = create_procyon_sectors(dsl, &procyon, &faction_lrak)?;
 
     setup_sector_connections(dsl, &alpha, &beta, &gamma)?;
-    populate_sectors_with_asteroids(ctx, dsl, &alpha, &beta)?;
+    populate_sectors_with_asteroids(dsl, &alpha, &beta)?;
     create_sector_stations(dsl, &alpha, &beta, &gamma, &faction_lrak)?;
     Ok(())
 }
 
 /// Creates the Procyon star system with all its celestial objects
-fn create_procyon_star_system<T: spacetimedsl::WriteContext>(
-    dsl: &DSL<T>,
+fn create_procyon_star_system(
+    dsl: &DSL<'_, ReducerContext>,
     faction_id: &FactionId,
 ) -> Result<StarSystem, String> {
     let procyon = dsl.create_star_system(CreateStarSystem {
@@ -112,8 +106,8 @@ fn create_procyon_star_system<T: spacetimedsl::WriteContext>(
 }
 
 /// Creates the three main sectors in the Procyon system
-fn create_procyon_sectors<T: spacetimedsl::WriteContext>(
-    dsl: &DSL<T>,
+fn create_procyon_sectors(
+    dsl: &DSL<'_, ReducerContext>,
     procyon: &StarSystem,
     faction_id: &FactionId,
 ) -> Result<(Sector, Sector, Sector), String> {
@@ -169,8 +163,8 @@ fn create_procyon_sectors<T: spacetimedsl::WriteContext>(
 }
 
 /// Sets up warp gate connections between sectors
-fn setup_sector_connections<T: spacetimedsl::WriteContext>(
-    dsl: &DSL<T>,
+fn setup_sector_connections(
+    dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     beta: &Sector,
     gamma: &Sector,
@@ -183,9 +177,8 @@ fn setup_sector_connections<T: spacetimedsl::WriteContext>(
 /// Populates sectors with asteroid fields, then stocks each field to its full
 /// target population so asteroids exist from t=0. The hourly `sector_upkeep`
 /// timer only replenishes fields after they've been mined down.
-fn populate_sectors_with_asteroids<T: spacetimedsl::WriteContext + 'static>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
+fn populate_sectors_with_asteroids(
+    dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     beta: &Sector,
 ) -> Result<(), String> {
@@ -204,15 +197,15 @@ fn populate_sectors_with_asteroids<T: spacetimedsl::WriteContext + 'static>(
         cluster_inner: None,
     })?;
 
-    fill_asteroid_sector(ctx, dsl, &alpha_field)?;
-    fill_asteroid_sector(ctx, dsl, &beta_field)?;
+    fill_asteroid_sector(dsl, &alpha_field)?;
+    fill_asteroid_sector(dsl, &beta_field)?;
 
     Ok(())
 }
 
 /// Creates stations in each sector with appropriate modules
-fn create_sector_stations<T: spacetimedsl::WriteContext + 'static>(
-    dsl: &DSL<T>,
+fn create_sector_stations(
+    dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     beta: &Sector,
     gamma: &Sector,
@@ -230,8 +223,8 @@ fn create_sector_stations<T: spacetimedsl::WriteContext + 'static>(
 /// 100% in one playtest. M4 will replace this with proper per-sector
 /// construction sites; for now this is the only test target the
 /// `contribute_to_station` reducer can point at after `--clear-database`.
-fn create_alpha_construction_site<T: spacetimedsl::WriteContext + 'static>(
-    dsl: &DSL<T>,
+fn create_alpha_construction_site(
+    dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     faction_id: &FactionId,
 ) -> Result<(), String> {
@@ -253,8 +246,8 @@ fn create_alpha_construction_site<T: spacetimedsl::WriteContext + 'static>(
 }
 
 /// Creates the trading station in Beta sector
-fn create_beta_trading_station<T: spacetimedsl::WriteContext + 'static>(
-    dsl: &DSL<T>,
+fn create_beta_trading_station(
+    dsl: &DSL<'_, ReducerContext>,
     beta: &Sector,
     faction_id: &FactionId,
 ) -> Result<(), String> {
@@ -274,8 +267,8 @@ fn create_beta_trading_station<T: spacetimedsl::WriteContext + 'static>(
 }
 
 /// Creates the refinery station in Alpha sector
-fn create_alpha_refinery_station<T: spacetimedsl::WriteContext + 'static>(
-    dsl: &DSL<T>,
+fn create_alpha_refinery_station(
+    dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     faction_id: &FactionId,
 ) -> Result<(), String> {
@@ -299,8 +292,8 @@ fn create_alpha_refinery_station<T: spacetimedsl::WriteContext + 'static>(
 }
 
 /// Creates the Gamma capital station
-fn create_gamma_capital_station<T: spacetimedsl::WriteContext + 'static>(
-    dsl: &DSL<T>,
+fn create_gamma_capital_station(
+    dsl: &DSL<'_, ReducerContext>,
     gamma: &Sector,
     faction_id: &FactionId,
 ) -> Result<(), String> {

--- a/server/src/definitions/mod.rs
+++ b/server/src/definitions/mod.rs
@@ -7,17 +7,14 @@ pub mod item_types;
 pub mod ship_types;
 pub mod station_module_types;
 
-pub fn init<T: spacetimedsl::WriteContext + 'static>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
-) -> Result<(), String> {
+pub fn init(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     factions::init(dsl)?;
     station_module_types::init(dsl)?;
     item_types::init(dsl)?;
     ship_types::init(dsl)?;
 
     // Init galaxy only AFTER all other definitions (it seeds asteroids, which need ctx.rng()).
-    galaxy::init(ctx, dsl)?;
+    galaxy::init(dsl)?;
 
     Ok(())
 }

--- a/server/src/definitions/mod.rs
+++ b/server/src/definitions/mod.rs
@@ -1,3 +1,4 @@
+use spacetimedb::ReducerContext;
 use spacetimedsl::*;
 
 pub mod factions;
@@ -6,14 +7,17 @@ pub mod item_types;
 pub mod ship_types;
 pub mod station_module_types;
 
-pub fn init<T: spacetimedsl::WriteContext + 'static>(dsl: &DSL<T>) -> Result<(), String> {
+pub fn init<T: spacetimedsl::WriteContext + 'static>(
+    ctx: &ReducerContext,
+    dsl: &DSL<T>,
+) -> Result<(), String> {
     factions::init(dsl)?;
     station_module_types::init(dsl)?;
     item_types::init(dsl)?;
     ship_types::init(dsl)?;
 
-    // Init galaxy only AFTER all other definitions
-    galaxy::init(dsl)?;
+    // Init galaxy only AFTER all other definitions (it seeds asteroids, which need ctx.rng()).
+    galaxy::init(ctx, dsl)?;
 
     Ok(())
 }

--- a/server/src/lifecycle/init.rs
+++ b/server/src/lifecycle/init.rs
@@ -9,7 +9,7 @@ use super::timers;
 pub fn init(ctx: &ReducerContext) -> Result<(), String> {
     let dsl = dsl(ctx);
 
-    definitions::init(ctx, &dsl)?;
+    definitions::init(&dsl)?;
     timers::initialize(&dsl)?;
 
     // Create a Global Config row, or reinitalize the one if it exists.

--- a/server/src/lifecycle/init.rs
+++ b/server/src/lifecycle/init.rs
@@ -9,7 +9,7 @@ use super::timers;
 pub fn init(ctx: &ReducerContext) -> Result<(), String> {
     let dsl = dsl(ctx);
 
-    definitions::init(&dsl)?;
+    definitions::init(ctx, &dsl)?;
     timers::initialize(&dsl)?;
 
     // Create a Global Config row, or reinitalize the one if it exists.

--- a/server/src/lifecycle/timers.rs
+++ b/server/src/lifecycle/timers.rs
@@ -25,7 +25,7 @@ use crate::{
 pub fn initialize<T: spacetimedsl::WriteContext>(dsl: &DSL<T>) -> Result<(), String> {
     // Sectors
     dsl.create_sector_upkeep_timer(CreateSectorUpkeepTimer {
-        scheduled_at: spacetimedb::ScheduleAt::Interval(Duration::from_hours(12).into()), // Every Minute
+        scheduled_at: spacetimedb::ScheduleAt::Interval(Duration::from_hours(1).into()), // Every hour — fields are seeded full at init; this only replenishes mined-out asteroids.
     })?;
 
     // Factions

--- a/server/src/logic/sectors/asteroid_fields.rs
+++ b/server/src/logic/sectors/asteroid_fields.rs
@@ -20,22 +20,21 @@ fn target_population(asteroid_sector: &AsteroidSector) -> usize {
 /// Spawns a single asteroid at a random position inside the field, with ore
 /// type skewed by the sector's rarity. Pure spawn logic — authorization is the
 /// calling reducer's responsibility. Returns `None` if the creation failed.
-fn spawn_random_asteroid_in_field<T: spacetimedsl::WriteContext>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
+fn spawn_random_asteroid_in_field(
+    dsl: &DSL<'_, ReducerContext>,
     asteroid_sector: &AsteroidSector,
 ) -> Option<Asteroid> {
     let field = *asteroid_sector.get_cluster_extent();
     let dist = match asteroid_sector.get_cluster_inner() {
-        Some(inner_extent) => ctx.rng().gen_range(*inner_extent..field), // Pick a distance between inner and outer bounds.
-        None => ctx.rng().gen_range(0.0..field),
+        Some(inner_extent) => dsl.ctx().rng().gen_range(*inner_extent..field), // Pick a distance between inner and outer bounds.
+        None => dsl.ctx().rng().gen_range(0.0..field),
     };
-    let pos = Vec2::from_glam(glam::Vec2::from_angle(ctx.rng().gen_range(0.0..2.0 * PI)) * dist);
+    let pos = Vec2::from_glam(glam::Vec2::from_angle(dsl.ctx().rng().gen_range(0.0..2.0 * PI)) * dist);
 
     let roll_with_disadvantage = {
-        let a = ctx.rng().gen_range(0..100);
+        let a = dsl.ctx().rng().gen_range(0..100);
         // Only ONE of the 'rolls' should be effected by rarity, so that there's always a chance for lower rarities.
-        let b = ctx
+        let b = dsl.ctx()
             .rng()
             .gen_range((*asteroid_sector.get_rarity() as i32)..100);
         if a < b {
@@ -54,13 +53,13 @@ fn spawn_random_asteroid_in_field<T: spacetimedsl::WriteContext>(
         _ => ITEM_URANIUM_ORE,
     });
 
-    let amount = ctx.rng().gen_range(500..2000);
+    let amount = dsl.ctx().rng().gen_range(500..2000);
 
     create_asteroid(
         dsl,
         pos,
         asteroid_sector.get_id(),
-        format!("asteroid.{}", ctx.rng().gen_range(1..=5)),
+        format!("asteroid.{}", dsl.ctx().rng().gen_range(1..=5)),
         item,
         amount,
     )
@@ -69,16 +68,15 @@ fn spawn_random_asteroid_in_field<T: spacetimedsl::WriteContext>(
 /// Fills a sector's asteroid field up to its target population in one pass.
 /// Called at galaxy init so fields are fully stocked from t=0; the hourly
 /// [`asteroid_sector_upkeep`] then only tops them back up after mining.
-pub fn fill_asteroid_sector<T: spacetimedsl::WriteContext>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
+pub fn fill_asteroid_sector(
+    dsl: &DSL<'_, ReducerContext>,
     asteroid_sector: &AsteroidSector,
 ) -> Result<(), String> {
     let target = target_population(asteroid_sector);
     let sector_id = asteroid_sector.get_id();
 
     while dsl.get_asteroids_by_current_sector_id(&sector_id).count() < target {
-        if spawn_random_asteroid_in_field(ctx, dsl, asteroid_sector).is_none() {
+        if spawn_random_asteroid_in_field(dsl, asteroid_sector).is_none() {
             // Bail rather than spin forever: a persistent creation failure would
             // never advance the count and would hang the init transaction.
             return Err(format!(
@@ -96,9 +94,8 @@ pub fn fill_asteroid_sector<T: spacetimedsl::WriteContext>(
 /// its target (e.g. after mining), spawns a single replacement. Runs hourly via
 /// `sector_upkeep`; bulk initial population happens at init via
 /// [`fill_asteroid_sector`].
-pub fn asteroid_sector_upkeep<T: spacetimedsl::WriteContext>(
-    ctx: &ReducerContext,
-    dsl: &DSL<T>,
+pub fn asteroid_sector_upkeep(
+    dsl: &DSL<'_, ReducerContext>,
     sector_id: &SectorId,
 ) -> Result<(), String> {
     try_server_only(dsl)?;
@@ -107,7 +104,7 @@ pub fn asteroid_sector_upkeep<T: spacetimedsl::WriteContext>(
     if dsl.get_asteroids_by_current_sector_id(sector_id).count()
         < target_population(&asteroid_sector)
     {
-        spawn_random_asteroid_in_field(ctx, dsl, &asteroid_sector).ok_or_else(|| {
+        spawn_random_asteroid_in_field(dsl, &asteroid_sector).ok_or_else(|| {
             format!(
                 "asteroid_sector_upkeep: create_asteroid failed in sector {}",
                 sector_id.value()

--- a/server/src/logic/sectors/asteroid_fields.rs
+++ b/server/src/logic/sectors/asteroid_fields.rs
@@ -2,6 +2,7 @@ use std::f32::consts::PI;
 
 use solarance_shared::Vec2;
 use spacetimedb::rand::Rng;
+use spacetimedb::ReducerContext;
 use spacetimedsl::*;
 
 use crate::{
@@ -10,60 +11,108 @@ use crate::{
     utility::try_server_only,
 };
 
-/// Function that maintains asteroid populations in sectors.
-/// Creates new asteroids when the count falls below the sector's sparseness threshold.
+/// Target number of asteroids a field tries to maintain, derived from its
+/// sparseness (e.g. sparseness 5 → 50 asteroids).
+fn target_population(asteroid_sector: &AsteroidSector) -> usize {
+    (asteroid_sector.get_sparseness() * 10).into()
+}
+
+/// Spawns a single asteroid at a random position inside the field, with ore
+/// type skewed by the sector's rarity. Pure spawn logic — authorization is the
+/// calling reducer's responsibility. Returns `None` if the creation failed.
+fn spawn_random_asteroid_in_field<T: spacetimedsl::WriteContext>(
+    ctx: &ReducerContext,
+    dsl: &DSL<T>,
+    asteroid_sector: &AsteroidSector,
+) -> Option<Asteroid> {
+    let field = *asteroid_sector.get_cluster_extent();
+    let dist = match asteroid_sector.get_cluster_inner() {
+        Some(inner_extent) => ctx.rng().gen_range(*inner_extent..field), // Pick a distance between inner and outer bounds.
+        None => ctx.rng().gen_range(0.0..field),
+    };
+    let pos = Vec2::from_glam(glam::Vec2::from_angle(ctx.rng().gen_range(0.0..2.0 * PI)) * dist);
+
+    let roll_with_disadvantage = {
+        let a = ctx.rng().gen_range(0..100);
+        // Only ONE of the 'rolls' should be effected by rarity, so that there's always a chance for lower rarities.
+        let b = ctx
+            .rng()
+            .gen_range((*asteroid_sector.get_rarity() as i32)..100);
+        if a < b {
+            a
+        } else {
+            b
+        }
+    };
+
+    let item = ItemDefinitionId::new(match roll_with_disadvantage {
+        0..25 => ITEM_ICE_ORE,
+        25..60 => ITEM_IRON_ORE,
+        60..75 => ITEM_SILICON_ORE,
+        75..85 => ITEM_GOLD_ORE,
+        85..90 => ITEM_VIVEIUM_ORE,
+        _ => ITEM_URANIUM_ORE,
+    });
+
+    let amount = ctx.rng().gen_range(500..2000);
+
+    create_asteroid(
+        dsl,
+        pos,
+        asteroid_sector.get_id(),
+        format!("asteroid.{}", ctx.rng().gen_range(1..=5)),
+        item,
+        amount,
+    )
+}
+
+/// Fills a sector's asteroid field up to its target population in one pass.
+/// Called at galaxy init so fields are fully stocked from t=0; the hourly
+/// [`asteroid_sector_upkeep`] then only tops them back up after mining.
+pub fn fill_asteroid_sector<T: spacetimedsl::WriteContext>(
+    ctx: &ReducerContext,
+    dsl: &DSL<T>,
+    asteroid_sector: &AsteroidSector,
+) -> Result<(), String> {
+    let target = target_population(asteroid_sector);
+    let sector_id = asteroid_sector.get_id();
+
+    while dsl.get_asteroids_by_current_sector_id(&sector_id).count() < target {
+        if spawn_random_asteroid_in_field(ctx, dsl, asteroid_sector).is_none() {
+            // Bail rather than spin forever: a persistent creation failure would
+            // never advance the count and would hang the init transaction.
+            return Err(format!(
+                "fill_asteroid_sector: create_asteroid failed in sector {}; aborting fill toward target {}",
+                sector_id.value(),
+                target
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Maintains asteroid populations in a sector. When a field has dropped below
+/// its target (e.g. after mining), spawns a single replacement. Runs hourly via
+/// `sector_upkeep`; bulk initial population happens at init via
+/// [`fill_asteroid_sector`].
 pub fn asteroid_sector_upkeep<T: spacetimedsl::WriteContext>(
-    ctx: &spacetimedb::ReducerContext,
+    ctx: &ReducerContext,
     dsl: &DSL<T>,
     sector_id: &SectorId,
 ) -> Result<(), String> {
-    // let ctx = dsl.ctx(); // No longer needed as passed explicitly
     try_server_only(dsl)?;
 
     let asteroid_sector = dsl.get_asteroid_sector_by_id(sector_id)?;
     if dsl.get_asteroids_by_current_sector_id(sector_id).count()
-        < (asteroid_sector.get_sparseness() * 10).into()
+        < target_population(&asteroid_sector)
     {
-        // 100
-        let field = *asteroid_sector.get_cluster_extent();
-        let dist = match asteroid_sector.get_cluster_inner() {
-            Some(inner_extent) => ctx.rng().gen_range(*inner_extent..field), // Pick a distance between inner and outer bounds.,
-            None => ctx.rng().gen_range(0.0..field),
-        };
-        let pos = Vec2::from_glam(glam::Vec2::from_angle(ctx.rng().gen_range(0.0..2.0 * PI)) * dist);
-
-        let roll_with_disadvantage = {
-            let a = ctx.rng().gen_range(0..100);
-            // Only ONE of the 'rolls' should be effected by rarity, so that there's always a chance for lower rarities.
-            let b = ctx
-                .rng()
-                .gen_range((*asteroid_sector.get_rarity() as i32)..100);
-            if a < b {
-                a
-            } else {
-                b
-            }
-        };
-
-        let item = ItemDefinitionId::new(match roll_with_disadvantage {
-            0..25 => ITEM_ICE_ORE,
-            25..60 => ITEM_IRON_ORE,
-            60..75 => ITEM_SILICON_ORE,
-            75..85 => ITEM_GOLD_ORE,
-            85..90 => ITEM_VIVEIUM_ORE,
-            _ => ITEM_URANIUM_ORE,
-        });
-
-        let amount = ctx.rng().gen_range(500..2000);
-
-        create_asteroid(
-            dsl,
-            pos,
-            sector_id.into(),
-            format!("asteroid.{}", ctx.rng().gen_range(1..=5)),
-            item,
-            amount,
-        );
+        spawn_random_asteroid_in_field(ctx, dsl, &asteroid_sector).ok_or_else(|| {
+            format!(
+                "asteroid_sector_upkeep: create_asteroid failed in sector {}",
+                sector_id.value()
+            )
+        })?;
     }
 
     Ok(())

--- a/server/src/logic/sectors/mod.rs
+++ b/server/src/logic/sectors/mod.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use spacetimedb::ReducerContext;
 use spacetimedsl::*;
 
@@ -31,7 +32,13 @@ pub fn sector_upkeep(ctx: &ReducerContext, _timer: SectorUpkeepTimer) -> Result<
 
     // If a sector has an asteroid_sector entry associated with it, then update it
     for sector in dsl.get_all_asteroid_sectors() {
-        let _ = asteroid_sector_upkeep(ctx, &dsl, &sector.get_id());
+        if let Err(e) = asteroid_sector_upkeep(ctx, &dsl, &sector.get_id()) {
+            warn!(
+                "asteroid_sector_upkeep failed for sector {}: {}",
+                sector.get_id().value(),
+                e
+            );
+        }
     }
 
     // Do other sector upkeep stuff here.

--- a/server/src/logic/sectors/mod.rs
+++ b/server/src/logic/sectors/mod.rs
@@ -32,7 +32,7 @@ pub fn sector_upkeep(ctx: &ReducerContext, _timer: SectorUpkeepTimer) -> Result<
 
     // If a sector has an asteroid_sector entry associated with it, then update it
     for sector in dsl.get_all_asteroid_sectors() {
-        if let Err(e) = asteroid_sector_upkeep(ctx, &dsl, &sector.get_id()) {
+        if let Err(e) = asteroid_sector_upkeep(&dsl, &sector.get_id()) {
             warn!(
                 "asteroid_sector_upkeep failed for sector {}: {}",
                 sector.get_id().value(),

--- a/server/src/logic/stations/mod.rs
+++ b/server/src/logic/stations/mod.rs
@@ -6,7 +6,6 @@ use crate::{
         status::*,
     },
     tables::{factions::*, items::*, sectors::*, stations::*, stellarobjects::*},
-    utility::*,
 };
 
 use log::info;

--- a/server/src/logic/stations/production.rs
+++ b/server/src/logic/stations/production.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use spacetimedb::{log::info, *};
-use spacetimedsl::*;
 
 use super::*;
 


### PR DESCRIPTION
Closes #128.

## Problem
The M4 refactor (#90) left the `sector_upkeep` timer firing every **12h** instead of 60s, and that timer is the *only* code path that creates asteroids — one per sector per tick. Asteroid fields never populated within a session, and on a fresh publish the first tick was 12h out. Full diagnosis: `agents/reports/asteroid-spawn-regression-2026-05-27.html`.

## Changes
- **Seed at init** — `populate_sectors_with_asteroids` now fills each field to its full target (`sparseness × 10`) via the new `fill_asteroid_sector`, so asteroids exist from t=0 (Alpha → 10, Beta → 50). `ctx` is threaded through the init chain so `ctx.rng()` is available.
- **Hourly cadence** — `sector_upkeep` timer changed `from_hours(12)` → `from_hours(1)`; it now only replenishes mined-out fields.
- **Surface the swallowed error** — `sector_upkeep`'s `let _ = …` replaced with a `warn!` naming the sector, per the Debugging Contract.
- **Refactor** — extracted `spawn_random_asteroid_in_field` + `target_population`; `asteroid_sector_upkeep` is now pure replenishment. `fill_asteroid_sector` bails with a contextual error rather than looping forever if a spawn fails.

`try_server_only` brittleness is intentionally out of scope (noted on #128).

## Verification
`spacetime publish --clear-database -y` → query `asteroid` immediately (expect 10 + 50) → mine some out → confirm replenishment within the hour and clean `spacetime logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)