### PR TITLE
Fix mining: enforce range continuously, not just at start (#130)

### DIFF
--- a/server/src/logic/ships/mining.rs
+++ b/server/src/logic/ships/mining.rs
@@ -10,6 +10,12 @@ use crate::{
     utility::try_server_only,
 };
 
+/// Maximum distance (world units) between a ship and an asteroid for mining.
+/// Enforced both when mining starts (`try_mining_asteroid`) and on every mining
+/// tick (`ship_mining_timer_reducer`), so a ship can't start in range and then
+/// drift away while extraction continues.
+pub const MINING_RANGE: f32 = 300.0;
+
 #[dsl(plural_name = ship_mining_timers, method(update = true))]
 #[spacetimedb::table(accessor = ship_mining_timer, scheduled(ship_mining_timer_reducer))]
 pub struct ShipMiningTimer {
@@ -73,6 +79,33 @@ pub fn ship_mining_timer_reducer(
         .next()
         .ok_or("Couldn't find ship.".to_string())?;
     let mut asteroid_object = dsl.get_asteroid_by_id(timer.get_asteroid_sobj_id())?;
+
+    // Range is enforced continuously, not just at start: if the ship has drifted
+    // beyond mining range, cancel the operation (delete the timer) and notify.
+    let ship_snapshot = crate::logic::stellarobjects::movement::get_ship_movement_snapshot(
+        &dsl,
+        &ship_object.get_id(),
+    )?;
+    if ship_snapshot
+        .pos
+        .distance_to_sq(asteroid_object.get_position())
+        > MINING_RANGE.powi(2)
+    {
+        dsl.delete_ship_mining_timer_by_id(timer.get_id())?;
+
+        let _ = send_info_message(
+            &dsl,
+            &ship_object.get_player_id(),
+            "Mining cancelled — asteroid out of range.".to_string(),
+            Some("mining"),
+        );
+        info!(
+            "Ship #{:?} drifted out of mining range of asteroid #{:?}; mining timer removed.",
+            ship_object.get_id(),
+            asteroid_object.get_id()
+        );
+        return Ok(());
+    }
 
     if *asteroid_object.get_current_resources() == 0 {
         dsl.delete_ship_mining_timer_by_id(timer.get_id())?;
@@ -221,9 +254,7 @@ pub fn try_mining_asteroid(
     let dist_sq = ship_snapshot.pos.distance_to_sq(asteroid.get_position());
 
     // If the player is trying to mine and is targetting an asteroid, create a mining timer.
-    if dist_sq < (300.0_f32).powi(2)
-    // TODO: Make mining range a config const
-    {
+    if dist_sq < MINING_RANGE.powi(2) {
         // Check if the player is already mining this asteroid
         if !dsl
             .get_ship_mining_timers_by_ship_sobj_id(&ship_object.get_sobj_id())


### PR DESCRIPTION
Closes #130.

## Problem
`try_mining_asteroid` gated on a 300-unit range, but the recurring `ship_mining_timer_reducer` never re-checked distance — so a ship could start mining in range and then fly anywhere in the sector while extraction kept running. Not intended gameplay.

## Changes
- Hoisted the 300-unit range into a shared `MINING_RANGE` const used by both the start-gate and the tick (resolves the `// TODO: Make mining range a config const`).
- Re-check distance each mining tick; on drift beyond `MINING_RANGE²`, delete the timer, send a `"mining"` ServerMessage (*"Mining cancelled — asteroid out of range."*), and stop — mirroring the existing asteroid-exhausted branch.

The deeper gap — mining state isn't client-observable, so server-initiated cancellations only surface via a text message — is tracked separately in #81 / #87 (notes added). This PR keeps the interim ServerMessage as the cancel signal.

## Verification
Start mining within range → fly past ~300 units → within one tick (~3s) confirm resource gain stops, the timer is gone, and a cancellation message arrives; `spacetime logs` shows the new cancel branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)