### PR TITLE
Bump SpacetimeDB to v2.3.0 across all Rust modules

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12.15", features = [
     "blocking",
     "rustls-tls",
 ], default-features = false }
-spacetimedb-sdk = "2.2.0"
+spacetimedb-sdk = "2.3.0"
 url = "2.5.4"
 solarance-shared = { path = "../solarance-shared" }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,8 +11,8 @@ authors = ["Karl Nyborg"]
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { version = "2.2.0" }
-spacetimedsl = "0.20.0"
+spacetimedb = { version = "2.3.0" }
+spacetimedsl = "0.20.1"
 log = "0.4"
 glam = "0.30.2"
 solarance-shared = { path = "../solarance-shared" }

--- a/solarance-shared/Cargo.toml
+++ b/solarance-shared/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-spacetimedb = "2.2.0"
+spacetimedb = "2.3.0"
 glam = "0.30.2"


### PR DESCRIPTION
## Summary
- Server + shared crate: `spacetimedb` 2.2.0 → 2.3.0; `spacetimedsl` 0.20.0 → 0.20.1
- Client: `spacetimedb-sdk` 2.2.0 → 2.3.0
- No source changes — `ReducerContext::identity` (deprecated in v2.3.0) is not used in `server/src/`; client `ctx.identity()` is on `DbConnection`/`EventContext`, which is unaffected

The v2.3.0 changelog highlights *DbContext generics* (for client/server code reuse) and the `ReducerContext::identity` → `database_identity` deprecation. Neither requires changes today: the DbContext-generics feature is an opportunity for `solarance-shared/` (separate work), and we don't call `ReducerContext::identity` anywhere on the server.

## Test plan
- [x] `task server:build` compiles clean against 2.3.0
- [x] `cargo build` on `client/` compiles clean against 2.3.0 (no new warnings beyond pre-existing dead-code ones)
- [x] Manual smoke: publish module to local spacetime, connect client, verify spawn / movement / mining / contribute flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)