### PR TITLE
Welcome-back panel: client-side render of welcome-back ServerMessage (#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ client/src/server/bindings/
 
 **/.env
 .DS_Store
+
+.claude/

--- a/client/src/gameplay.rs
+++ b/client/src/gameplay.rs
@@ -173,15 +173,6 @@ pub async fn gameplay(connection: Option<DbConnection>) {
         visual_effects::render_visual_effects(&game_state);
 
         egui_macroquad::ui(|egui_ctx| {
-            // Welcome-back panel (#100): shows once on connect regardless of
-            // whether the player is piloting, docked, or still on the creation
-            // screen. Self-suppresses after dismissal.
-            gui::welcome_back_widget::draw(
-                egui_ctx,
-                &game_state.ctx,
-                &mut game_state.welcome_back,
-            );
-
             if player_ship.is_none() {
                 if ctx
                     .db()
@@ -237,6 +228,16 @@ pub async fn gameplay(connection: Option<DbConnection>) {
                     &mut game_state.construction_window_open,
                 );
             }
+
+            // Welcome-back panel (#100): shows once on connect regardless of
+            // whether the player is piloting, docked, or still on the creation
+            // screen. Self-suppresses after dismissal.
+            // Renders last so it's always on top!
+            gui::welcome_back_widget::draw(
+                egui_ctx,
+                &game_state.ctx,
+                &mut game_state.welcome_back,
+            );
         });
 
         egui_macroquad::draw();

--- a/client/src/gameplay.rs
+++ b/client/src/gameplay.rs
@@ -173,6 +173,15 @@ pub async fn gameplay(connection: Option<DbConnection>) {
         visual_effects::render_visual_effects(&game_state);
 
         egui_macroquad::ui(|egui_ctx| {
+            // Welcome-back panel (#100): shows once on connect regardless of
+            // whether the player is piloting, docked, or still on the creation
+            // screen. Self-suppresses after dismissal.
+            gui::welcome_back_widget::draw(
+                egui_ctx,
+                &game_state.ctx,
+                &mut game_state.welcome_back,
+            );
+
             if player_ship.is_none() {
                 if ctx
                     .db()

--- a/client/src/gameplay/gui.rs
+++ b/client/src/gameplay/gui.rs
@@ -11,3 +11,4 @@ pub mod minimap_widget;
 pub mod out_of_play_screen;
 pub mod ship_details_window;
 pub mod status_widget;
+pub mod welcome_back_widget;

--- a/client/src/gameplay/gui/welcome_back_widget.rs
+++ b/client/src/gameplay/gui/welcome_back_widget.rs
@@ -1,0 +1,83 @@
+//! Welcome-back panel (#100) — the client-side render half of the welcome-back
+//! feature whose server-side composition landed in #92.
+//!
+//! On connect the server composes a single text-only `ServerMessage` tagged
+//! with `WELCOME_BACK_CONTEXT` and routes it to the player. This widget detects
+//! that message and shows it once, in a cozy centered panel, so a returning
+//! player learns at a glance what changed while they were away. Closing the
+//! panel marks the message read and suppresses it for the rest of the session.
+
+use egui::{Align2, Color32, Context, RichText};
+use spacetimedb_sdk::DbContext;
+
+use crate::{gameplay::server_messages::ServerMessageUtils, server::bindings::DbConnection};
+
+/// Per-session state for the welcome-back panel.
+#[derive(Default)]
+pub struct State {
+    /// Set once the player dismisses the panel. Session-scoped, so a welcome-back
+    /// is never re-shown after the player closes it — even if a later frame still
+    /// finds the (now-read) message in the cache.
+    pub dismissed: bool,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Draw the welcome-back panel if there is an undismissed welcome-back message.
+///
+/// Cheap no-op once dismissed, or when no welcome-back message exists yet (the
+/// subscription may not have delivered it on the first frame after connect —
+/// we simply pick it up on whichever frame it arrives).
+pub fn draw(egui_ctx: &Context, ctx: &DbConnection, state: &mut State) {
+    if state.dismissed {
+        return;
+    }
+
+    let Some((message, _recipient)) =
+        ServerMessageUtils::get_latest_welcome_back(ctx, &ctx.identity())
+    else {
+        return;
+    };
+
+    let mut close_requested = false;
+
+    egui::Window::new("Welcome Back")
+        .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .resizable(false)
+        .collapsible(false)
+        .movable(false)
+        .min_width(360.0)
+        .show(egui_ctx, |ui| {
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new("Welcome back, pilot")
+                    .heading()
+                    .color(Color32::from_rgb(120, 190, 255)),
+            );
+            ui.separator();
+            ui.add_space(4.0);
+
+            // The server joins the summary lines with '\n'; egui renders the
+            // newlines directly. Keep it text-only and easy to read at a glance.
+            ui.label(RichText::new(&message.message).size(15.0));
+
+            ui.add_space(8.0);
+            ui.separator();
+            ui.vertical_centered(|ui| {
+                if ui.button("Dismiss").clicked() {
+                    close_requested = true;
+                }
+            });
+        });
+
+    if close_requested {
+        // Mark read so the chat unread indicator clears too; failures here are
+        // non-fatal (the session-level `dismissed` flag still hides the panel).
+        let _ = ServerMessageUtils::mark_message_as_read(ctx, message.id);
+        state.dismissed = true;
+    }
+}

--- a/client/src/gameplay/server_messages.rs
+++ b/client/src/gameplay/server_messages.rs
@@ -1,6 +1,12 @@
 use crate::server::bindings::*;
 use spacetimedb_sdk::{DbContext, Identity, Table};
 
+/// Discriminator the server stamps on the welcome-back message's
+/// `sender_context` (see `server/src/logic/players/welcome_back.rs`,
+/// `WELCOME_BACK_CONTEXT`). Keep in sync with the server-side constant — it is
+/// how the client tells a welcome-back apart from a generic notification.
+pub const WELCOME_BACK_CONTEXT: &str = "welcome_back";
+
 /// Client-side utilities for handling server messages
 pub struct ServerMessageUtils;
 
@@ -47,6 +53,24 @@ impl ServerMessageUtils {
     /// Get count of unread server messages for the current player
     pub fn get_unread_count(ctx: &DbConnection, player_id: &Identity) -> usize {
         Self::get_unread_messages_for_player(ctx, player_id).len()
+    }
+
+    /// Find the most recent welcome-back message for the current player, if any.
+    ///
+    /// The welcome-back panel (#100) renders this; it is the server-composed
+    /// `ServerMessage` tagged with [`WELCOME_BACK_CONTEXT`]. Returns the newest
+    /// one so a reconnect supersedes any stale welcome-back left unread from a
+    /// previous session.
+    pub fn get_latest_welcome_back(
+        ctx: &DbConnection,
+        player_id: &Identity,
+    ) -> Option<(ServerMessage, ServerMessageRecipient)> {
+        // `get_messages_for_player` already returns newest-first.
+        Self::get_messages_for_player(ctx, player_id)
+            .into_iter()
+            .find(|(message, _)| {
+                message.sender_context.as_deref() == Some(WELCOME_BACK_CONTEXT)
+            })
     }
 
     /// Mark a server message as read

--- a/client/src/gameplay/state.rs
+++ b/client/src/gameplay/state.rs
@@ -30,6 +30,7 @@ pub struct GameState<'a> {
     pub details_window: ship_details_window::State,
     pub faction_window: faction_window::State,
     pub map_window: map_window::State,
+    pub welcome_back: welcome_back_widget::State,
 
     pub out_of_play_screen: out_of_play_screen::State,
 
@@ -75,6 +76,7 @@ pub fn initialize<'a>(ctx: &'a DbConnection) -> GameState<'a> {
         details_window: ship_details_window::State::new(),
         faction_window: faction_window::State::new(),
         map_window: map_window::State::new(),
+        welcome_back: welcome_back_widget::State::new(),
 
         out_of_play_screen: out_of_play_screen::State::new(),
 


### PR DESCRIPTION
Closes #100.

## What

The client-side render half of the welcome-back feature. #92 composes the welcome-back `ServerMessage` server-side on `client_connected`; this PR makes the returning player actually see it.

On connect, a dedicated centered egui panel renders the server-composed summary — station progress, contributions since last login, and current cargo — and the player dismisses it with one click.

## How

- **`ServerMessageUtils::get_latest_welcome_back`** keys off the shared `"welcome_back"` `sender_context` (mirrored from the server's `WELCOME_BACK_CONTEXT`) to pick the newest welcome-back message, separating it from the generic Server notification tab. Returns newest-first so a reconnect supersedes any stale unread welcome-back.
- **`welcome_back_widget`** draws a text-only, cozy, non-movable centered window. The server joins its summary lines with `\n`; egui renders them directly.
- **Dismiss** marks the message read (so the existing chat unread indicator clears too) and sets a session-scoped `dismissed` flag, so it never re-shows this session — even if a later frame still finds the now-read row in cache.
- Drawn at the top of the egui loop, so it appears whether the player is piloting, docked, or on the out-of-play screen. The server only composes the message for registered players (`if let Ok(player) = dsl.get_player_by_id(...)`), so brand-new identities on the creation screen see nothing.

Subscriptions for `server_message` / `server_message_recipient` (filtered to the player) already existed, so no subscription changes were needed.

## Scope notes

- Notification scopes/priorities are out of scope here — that's #101.
- Text-only, no LLM, per the issue.

## Verification

- `cargo check` passes (no new warnings).
- Manual end-to-end (logging in against a live module and observing the panel) requires a running SpacetimeDB instance + login flow; not exercised in this change. The panel keys off the same `ServerMessage`/`ServerMessageRecipient` rows the existing Server chat tab already reads, so the data path is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)