### PR TITLE
M2 cleanup: messaging design (#101 resolution) + milestones snapshot

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,21 @@ Strict hierarchical containers for the game world.
 *   **Server Offset:** Client-side estimator that aligns the local clock to the server's clock so `predict_movement` doesn't see negative deltas (frozen ship) or oversized deltas (snap-forward). Computed as a maximum aggregator over recent snapshots; surfaced in the debug widget.
 *   **Static Position:** Non-moving entities (`Asteroid`, `Station`, `Jumpgate`) carry `(x, y)` (and `rotation` for stations and jumpgates) as direct table columns. They do not have a `MovementState`. Asteroid spin is pure client-side animation derived from `asteroid_id ⊕ time`.
 
-## 5. Anti-Concepts (Banned Terminology)
+## 5. Messaging
+Two distinct messaging systems. They do not share tables. Choosing between them *is* choosing the audience, which is why there is no separate "scope" column.
+
+*   **Direct Server Message** (`DirectServerMessage`): A 1-to-1 message FROM the Server TO a single Player. Server is *always* the sender — there is no sender enum on this table. Replaces the old `ServerMessage` + `ServerMessageRecipient` pair and most existing `send_server_message_*` usages. The **Welcome-Back Summary** is delivered as a Direct Server Message. Player→player DMs are **out of MVP scope**; when added they will be a *separate* table (`DirectMessage`), not a reschema of this one. *(Do not use: ServerMessage, notification, PM, whisper.)*
+*   **Channel Message:** A 1-to-many message posted to a **Channel**. Everyone subscribed to that Channel sees it. Fire-and-forget — no per-player delivery or read state is stored. *(Do not use: broadcast, group message.)*
+*   **Channel:** The audience of a Channel Message. This replaces issue #101's proposed `Scope` enum: scope is *which Channel table you posted to*, not a stored column. The Channels, broadest to narrowest:
+    *   **Server** (`ServerChannelMessage`): server-wide MOTD / updates. Sender is always `System`. Truly **public** — readable by anyone connected (incl. not-logged-in / banned) and surfaceable outside the game (e.g. a webpage). No View.
+    *   **Galaxy** (`GalaxyChannelMessage`): galaxy-wide *player* chat. Gated to logged-in players (good-standing check added later) via a View. Distinct from Server so player chatter never mixes with official announcements.
+    *   **Star System** (`StarSystemChannelMessage`): scoped to one `StarSystem` (`system_id`). In MVP there is one StarSystem, so this is *effectively* galaxy-wide today, but stays separate so it scopes correctly when more systems ship.
+    *   **Sector** (`SectorChannelMessage`): scoped to one `Sector` (`sector_id`); audience is players whose Ship is in that Sector.
+    *   **Faction** (`FactionChannelMessage`): scoped to one `Faction` (`faction_id`).
+*   **Message Sender** (`MessageSender` enum): The author of a **Channel Message** — `Player(Identity)` or `System`. Lives only on the five channel tables (so System can post into any channel). `DirectServerMessage` has *no* sender field — its sender is always the Server, implicitly.
+*   **Read state (login-relative):** Not stored server-side for either system. A message is "unread" if its `created_at` is later than the Player's `last_login`; the client highlights those and clears the highlight once the Player next sends a message.
+
+## 6. Anti-Concepts (Banned Terminology)
 To prevent scope creep, these terms are explicitly banned from MVP code, PRs, and design discussions. Once the MVP is released, this list will be updated. If you see them, flag them for the `Future Vision` backlog:
 
 *   🚫 **Combat / Attack / Health (for ships) / Weapons** -> (Exterminate pillar is absent).
@@ -55,6 +69,19 @@ To prevent scope creep, these terms are explicitly banned from MVP code, PRs, an
 *   🚫 **Orchestrator / Handoff** -> (Over-engineering for <10 concurrent players).
 
 ---
+
+### Messaging design decisions (issue #101, resolved 2026-05-30)
+- `ServerMessage`/`ServerMessageRecipient` are split into **Direct Message** (1-to-1, server can be sender) and **Channel Message** (1-to-many, fire-and-forget). Six message tables total: `ServerChannelMessage`, `GalaxyChannelMessage`, `StarSystemChannelMessage`, `SectorChannelMessage`, `FactionChannelMessage`, `DirectServerMessage`. The five channel tables share `{ id, sender: MessageSender, body, created_at }` plus their indexed scope key; `DirectServerMessage` is `{ id, to: Identity (indexed), body, created_at }` with **no** sender field (server is always sender).
+- **`MessageSender` enum lives only on channel tables**, not on `DirectServerMessage`. Player→player DM, if ever built, is a separate `DirectMessage` table.
+- **Server vs Galaxy are deliberately two tables**: Server = official/public/no-view; Galaxy = player chat/gated/view. Kept separate so post-MVP multi-system growth is clean and so official announcements can live outside the game client.
+- **No server-side windowing on any channel.** Views return the full filtered set; the client may limit how many it subscribes to. Client windowing (default last ~10 + "look back") is **post-MVP**.
+- **View legality (no `.iter()` full scans):** StarSystem/Sector/Faction/DM views filter on their natural indexed FK. **Galaxy** has no natural key, so it carries a constant indexed `galaxy_id` (always `0` in MVP) the view filters on, plus an in-body `is logged-in?` gate (non-players / banned get an empty result). The `galaxy_id` column exists solely to keep the gated, un-windowed view legal; the whole-table read set is acceptable at MVP scale. Server channel needs no view, so no such key.
+- The `ServerMessageRecipient` join table is dropped — DM recipient is a column, read state is login-relative and client-derived.
+- Issue #101's `Scope` enum and `priority` field are dropped: scope is the Channel; priority is not modeled.
+- **Sender is a `MessageSender` enum** (`Player(Identity)` + `System` to start; `Station` etc. added when needed). It is display-only.
+- **All message tables are private; clients see them only through STDB Views** (`#[spacetimedb::view]`). Views are read-only Rust functions, so they may branch on enums/`Option` freely (the `MessageSender` enum is fine). Two real View constraints drive the schema instead:
+  - **No full table scans** — a View may only reach a table via *indexed* `.find()`/`.filter()`. So every per-audience View filters on an **indexed** column (`to`, `sector_id`, `faction_id`). A View that returns "all rows" is illegal.
+  - **Per-caller Views are O(subscribers)** — a View using `ctx.sender()` (`ViewContext`) is recomputed per client. DM/Sector/Faction Views are per-caller (unavoidable; fine at <10 players). Prefer `AnonymousViewContext` (shared) where the audience isn't caller-specific.
 
 ### How to use this document
 - **When writing Code:** Name your classes strictly after these terms. E.g., `class ContributionPool`, `struct WelcomeBackSummary`, `fn extract_resource()`.

--- a/agents/reports/milestones.html
+++ b/agents/reports/milestones.html
@@ -679,7 +679,7 @@
         what's done, what's next, what each exit gate looks like, and which issues sit underneath each goal.
       </p>
       <div class="hero-meta">
-        <span><strong style="color: var(--accent);">Last updated:</strong> <strong>2026-05-28</strong></span>
+        <span><strong style="color: var(--accent);">Last updated:</strong> <strong>2026-06-04</strong></span>
         <span><strong>Repo:</strong> GalaxyCr8r/solarance-beginnings</span>
         <span><strong>Active plan:</strong> M1 → M7 (post-MVP gated on success criterion 5)</span>
         <span><strong>Source:</strong> live <code>gh api /milestones</code></span>
@@ -698,14 +698,14 @@
           <div class="desc">M1 (Shared-Building Spike) cleared all 5 issues. Six MVP milestones remain.</div>
         </div>
         <div class="stat">
-          <div class="n warn">29</div>
+          <div class="n warn">25</div>
           <div class="lbl">Open MVP issues</div>
-          <div class="desc">Across M2–M7. Two regression bugs surfaced 2026-05-27 while working M2: <strong style="color:var(--bad)">#128</strong> asteroid spawning broke in the M4 refactor, and <strong style="color:var(--bad)">#130</strong> mining ignores range after start. Both filed against M5, PRs open on <code>0.5.0</code>.</div>
+          <div class="desc">Across M2–M7. M2 down to two stretch items (<strong>#101</strong> notification scopes, <strong>#102</strong> persistence smoke test). The two M5 regressions filed during M2 work — <strong style="color:var(--bad)">#128</strong> asteroids and <strong style="color:var(--bad)">#130</strong> mining range — were both fixed on <code>main</code> via #131 / #132.</div>
         </div>
         <div class="stat">
-          <div class="n info">5</div>
+          <div class="n info">9</div>
           <div class="lbl">MVP issues closed</div>
-          <div class="desc">All from M1. <strong style="color:var(--purple)">#92</strong> shipped to <code>0.5.0</code> via #129 on 2026-05-27 and will auto-close on the next main integration.</div>
+          <div class="desc">5 from M1, 4 from M2. Welcome-back loop end-to-end (<strong>#92</strong> + <strong>#100</strong>) plus stale-row-cache cleanup (<strong>#123</strong> + <strong>#124</strong>) all landed on <code>main</code> on <code>2026-05-30</code> via PR #140 (0.5.0 integration).</div>
         </div>
         <div class="stat">
           <div class="n dim">46</div>
@@ -728,9 +728,7 @@
       <div class="now-banner">
         <div class="now-tag">CURRENT FOCUS</div>
         <div class="now-body">
-          <strong>M2 — Persistence + Welcome-Back</strong> is the active milestone. Server-side welcome-back composition (<strong>#92</strong>) shipped to <code>0.5.0</code> via <code>#129</code> on
-          <code>2026-05-27</code>; the client-side rendering (<strong>#100</strong>) and notification scopes (<strong>#101</strong>) are next.
-          Two unrelated server regressions surfaced during this work and were split off to M5: <strong>#128</strong> (asteroids) and <strong>#130</strong> (mining range), PRs open against <code>0.5.0</code>.
+          <strong>M2 — Persistence + Welcome-Back</strong> is substantially complete on <code>main</code>: the welcome-back loop end-to-end (server <strong>#92</strong> + client <strong>#100</strong>) and the stale-row-cache cleanup (<strong>#123</strong> + <strong>#124</strong>) all landed via PR <code>#140</code> on <code>2026-05-30</code>, retiring the <code>0.5.0</code> integration branch. Remaining: notification scopes (<strong>#101</strong>) and the persistence smoke-test writeup (<strong>#102</strong>). Two M5 regressions caught en route — <strong>#128</strong> asteroids and <strong>#130</strong> mining range — are fixed on main but the issues haven't auto-closed.
         </div>
       </div>
 
@@ -796,31 +794,31 @@
         </article>
 
         <!-- ============ M2 ============ -->
-        <article class="ms active" id="m2" data-progress="17">
+        <article class="ms active" id="m2" data-progress="67">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M2</span>Persistence + Welcome-Back 💾</h3>
-            <span class="ms-status active">● Active · 1/6</span>
+            <span class="ms-status active">● Active · 4/6 · welcome-back loop shipped</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
             Stations and contributions survive server restart. <code>client_connected</code> composes a text-only welcome-back ServerMessage with station progress, contributions since last login, and current cargo. <em>Log out, come back next day, welcome-back accurately reflects what changed.</em>
           </div>
           <div class="progress">
-            <div class="progress-track"><div class="progress-fill" data-fill="17"></div></div>
-            <div class="progress-label">17% · 1 in 0.5.0 · 5 open</div>
+            <div class="progress-track"><div class="progress-fill" data-fill="67"></div></div>
+            <div class="progress-label">67% · 4 closed · 2 open</div>
           </div>
           <ul class="issues">
-            <li class="issue open">
-              <span class="issue-state open" title="open">○</span>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed via PR #137">✓</span>
               <span class="issue-num">#123</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/123">Client caches SpacetimeDB rows that go stale on eviction → crashes</a>
-              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip client-side">client</span></span>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip client-side">client</span><span class="chip in-050">on main · #137</span></span>
             </li>
-            <li class="issue open">
-              <span class="issue-state open">○</span>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed via PR #137">✓</span>
               <span class="issue-num">#124</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/124">Reshape stdb/utils.rs around domain queries (house the validate-on-read)</a>
-              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span></span>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip in-050">on main · #137</span></span>
             </li>
             <li class="issue open">
               <span class="issue-state open" title="open">○</span>
@@ -834,17 +832,17 @@
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/101">ServerMessage notification scopes (personal/faction/system) + priorities</a>
               <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip server-side">server</span></span>
             </li>
-            <li class="issue open">
-              <span class="issue-state open">○</span>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed via PR #136">✓</span>
               <span class="issue-num">#100</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/100">Welcome-back panel: client-side rendering of the welcome-back ServerMessage</a>
-              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span></span>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip in-050">on main · #136</span></span>
             </li>
-            <li class="issue shipped">
-              <span class="issue-state shipped" title="Merged to 0.5.0 via #129">→</span>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed via PR #129 (then onto main via #140)">✓</span>
               <span class="issue-num">#92</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/92">Welcome-Back ServerMessage (server-side composition) [split from #82]</a>
-              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip server-side">server</span><span class="chip in-050">in 0.5.0 · #129</span></span>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip server-side">server</span><span class="chip in-050">on main · #129 → #140</span></span>
             </li>
           </ul>
         </article>
@@ -963,20 +961,20 @@
           </div>
           <div class="progress">
             <div class="progress-track"><div class="progress-fill" data-fill="0"></div></div>
-            <div class="progress-label">0% · 8 open · 2 PRs in flight</div>
+            <div class="progress-label">0% · 8 open · #128 and #130 fixed on main (issues pending close)</div>
           </div>
           <ul class="issues">
             <li class="issue open">
-              <span class="issue-state open" title="open">○</span>
+              <span class="issue-state open" title="open — fix landed but issue still open">○</span>
               <span class="issue-num">#130</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/130">Mining continues from anywhere in-sector — range is only checked at start</a>
-              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip pr-flight">PR #132 → 0.5.0</span></span>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip in-050">fix on main · #132</span></span>
             </li>
             <li class="issue open">
-              <span class="issue-state open" title="open">○</span>
+              <span class="issue-state open" title="open — fix landed but issue still open">○</span>
               <span class="issue-num">#128</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/128">Asteroids no longer spawn — seed fields fully at init + hourly maintenance cadence</a>
-              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip pr-flight">PR #131 → 0.5.0</span></span>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip in-050">fix on main · #131</span></span>
             </li>
             <li class="issue open">
               <span class="issue-state open">○</span>
@@ -1157,7 +1155,7 @@
 
     <footer>
       <img class="footer-mark" src="../assets/Solarance_Icon.png" alt="Solarance" />
-      Milestones snapshot · 2026-05-28 · Solarance: Beginnings · Source:
+      Milestones snapshot · 2026-06-04 · Solarance: Beginnings · Source:
       <a href="https://github.com/GalaxyCr8r/solarance-beginnings/milestones">github.com/GalaxyCr8r/solarance-beginnings/milestones</a>
     </footer>
 


### PR DESCRIPTION
## Summary

- Resolve the open design question on **#101** in `CONTEXT.md`: replace the proposed `Scope` enum + `priority` field with a Direct-Message vs Channel-Message split. Six message tables total (one DM, five channels); scope *is* which channel table you posted to. Captures the View-legality constraints (no full scans, per-caller views are O(subscribers)) that shaped the schema.
- Refresh `agents/reports/milestones.html` to the 2026-06-04 snapshot: M2 at 4/6 with the welcome-back loop landed on `main` via #140; #128/#130 fixes consolidated; 0.5.0 integration branch retired.

Branch name (`issue-102-…`) is loose — #102 was closed separately. This PR is the M2 documentation cleanup so #101 can move forward.

## Test plan

- [x] CONTEXT.md renders cleanly on GitHub (section anchors, list nesting)
- [x] `agents/reports/milestones.html` opens locally; M2 card shows 67% / 4 closed / 2 open
- [x] No code changes — no build / test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)