### PR TITLE
M3: Rediar capital sector, spawn-at-capital, one-ship guard (#105, #103)

### DIFF
--- a/agents/reports/milestones.html
+++ b/agents/reports/milestones.html
@@ -488,6 +488,7 @@
   .chip.agent-human-needed { color: var(--pink); border-color: rgba(255, 158, 198, 0.4); background: rgba(255, 158, 198, 0.08); }
   .chip.in-050        { color: var(--purple);   border-color: rgba(184, 158, 255, 0.45); background: rgba(184, 158, 255, 0.12); }
   .chip.pr-flight     { color: var(--accent-2); border-color: rgba(122, 168, 255, 0.45); background: rgba(122, 168, 255, 0.12); }
+  .chip.future-vision { color: var(--pink);     border-color: rgba(255, 158, 198, 0.4);  background: rgba(255, 158, 198, 0.08); }
 
   /* ---------- Pull quote ---------- */
   blockquote.pullquote {
@@ -679,7 +680,7 @@
         what's done, what's next, what each exit gate looks like, and which issues sit underneath each goal.
       </p>
       <div class="hero-meta">
-        <span><strong style="color: var(--accent);">Last updated:</strong> <strong>2026-06-04</strong></span>
+        <span><strong style="color: var(--accent);">Last updated:</strong> <strong>2026-06-10</strong></span>
         <span><strong>Repo:</strong> GalaxyCr8r/solarance-beginnings</span>
         <span><strong>Active plan:</strong> M1 → M7 (post-MVP gated on success criterion 5)</span>
         <span><strong>Source:</strong> live <code>gh api /milestones</code></span>
@@ -693,19 +694,19 @@
 
       <div class="stats">
         <div class="stat">
-          <div class="n">1<span style="font-size: 22px; color: var(--text-dim);"> / 7</span></div>
+          <div class="n">2<span style="font-size: 22px; color: var(--text-dim);"> / 7</span></div>
           <div class="lbl">MVP milestones complete</div>
-          <div class="desc">M1 (Shared-Building Spike) cleared all 5 issues. Six MVP milestones remain.</div>
+          <div class="desc">M1 (Shared-Building Spike) and M2 (Persistence + Welcome-Back) both fully closed. Five MVP milestones remain.</div>
         </div>
         <div class="stat">
-          <div class="n warn">25</div>
+          <div class="n warn">27</div>
           <div class="lbl">Open MVP issues</div>
-          <div class="desc">Across M2–M7. M2 down to two stretch items (<strong>#101</strong> notification scopes, <strong>#102</strong> persistence smoke test). The two M5 regressions filed during M2 work — <strong style="color:var(--bad)">#128</strong> asteroids and <strong style="color:var(--bad)">#130</strong> mining range — were both fixed on <code>main</code> via #131 / #132.</div>
+          <div class="desc">Across M3–M7. Three new issues filed during the #101 messaging playtest: <strong>#141</strong> mining desync on reconnect, <strong>#144</strong> crate-pickup UI lost in a refactor, <strong>#145</strong> server-admin client (the runtime sibling of #34's Galaxy Creator).</div>
         </div>
         <div class="stat">
-          <div class="n info">9</div>
+          <div class="n info">15</div>
           <div class="lbl">MVP issues closed</div>
-          <div class="desc">5 from M1, 4 from M2. Welcome-back loop end-to-end (<strong>#92</strong> + <strong>#100</strong>) plus stale-row-cache cleanup (<strong>#123</strong> + <strong>#124</strong>) all landed on <code>main</code> on <code>2026-05-30</code> via PR #140 (0.5.0 integration).</div>
+          <div class="desc">5 from M1, 8 from M2, 2 from M5. M2 closed out with the messaging redesign (<strong>#101</strong> → PR #143: six tables, first STDB Views in the codebase) and the persistence smoke test (<strong>#102</strong>). M5's regressions <strong>#128</strong> / <strong>#130</strong> are now closed via #131 / #132.</div>
         </div>
         <div class="stat">
           <div class="n dim">46</div>
@@ -728,7 +729,7 @@
       <div class="now-banner">
         <div class="now-tag">CURRENT FOCUS</div>
         <div class="now-body">
-          <strong>M2 — Persistence + Welcome-Back</strong> is substantially complete on <code>main</code>: the welcome-back loop end-to-end (server <strong>#92</strong> + client <strong>#100</strong>) and the stale-row-cache cleanup (<strong>#123</strong> + <strong>#124</strong>) all landed via PR <code>#140</code> on <code>2026-05-30</code>, retiring the <code>0.5.0</code> integration branch. Remaining: notification scopes (<strong>#101</strong>) and the persistence smoke-test writeup (<strong>#102</strong>). Two M5 regressions caught en route — <strong>#128</strong> asteroids and <strong>#130</strong> mining range — are fixed on main but the issues haven't auto-closed.
+          <strong>M2 is done — M3 (Two-Faction MVP Setup) is up next.</strong> M2 closed out with the #101 messaging redesign (PR <code>#143</code>): <code>ServerMessage</code>/<code>ServerMessageRecipient</code> replaced by five Channel tables + <code>DirectServerMessage</code>, the codebase's <strong>first STDB Views</strong> (a preview of M7's anti-cheat work), and login-relative read state. Design rationale lives in <code>docs/adr/0001-messaging-redesign.md</code>. The playtest surfaced three new issues — <strong>#141</strong> (mining desync, M5), <strong>#144</strong> (crate pickup UI, M5), <strong>#145</strong> (server-admin client, M4) — all triaged into later milestones. M3 has no started issues yet.
         </div>
       </div>
 
@@ -794,20 +795,44 @@
         </article>
 
         <!-- ============ M2 ============ -->
-        <article class="ms active" id="m2" data-progress="67">
+        <article class="ms done" id="m2" data-progress="100">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M2</span>Persistence + Welcome-Back 💾</h3>
-            <span class="ms-status active">● Active · 4/6 · welcome-back loop shipped</span>
+            <span class="ms-status done">✓ Complete · 8/8</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
-            Stations and contributions survive server restart. <code>client_connected</code> composes a text-only welcome-back ServerMessage with station progress, contributions since last login, and current cargo. <em>Log out, come back next day, welcome-back accurately reflects what changed.</em>
+            Stations and contributions survive server restart. <code>client_connected</code> composes a text-only welcome-back message with station progress, contributions since last login, and current cargo. <em>Log out, come back next day, welcome-back accurately reflects what changed.</em>
           </div>
           <div class="progress">
-            <div class="progress-track"><div class="progress-fill" data-fill="67"></div></div>
-            <div class="progress-label">67% · 4 closed · 2 open</div>
+            <div class="progress-track"><div class="progress-fill" data-fill="100"></div></div>
+            <div class="progress-label">100% · 8 closed</div>
           </div>
           <ul class="issues">
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed via PR #143 — messaging redesign">✓</span>
+              <span class="issue-num">#101</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/101">ServerMessage notification scopes — resolved by the messaging redesign (Channel + DirectServerMessage)</a>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip server-side">server</span><span class="chip in-050">on main · #143</span></span>
+            </li>
+            <li class="issue closed">
+              <span class="issue-state closed" title="closed">✓</span>
+              <span class="issue-num">#102</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/102">Persistence smoke test: stations + contributions survive server restart</a>
+              <span class="issue-labels"><span class="chip documentation">docs</span><span class="chip server-side">server</span></span>
+            </li>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Fix for #128, tracked + closed in M2">✓</span>
+              <span class="issue-num">#131</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/131">Fix asteroid spawning: seed fields at init + hourly upkeep (#128)</a>
+              <span class="issue-labels"><span class="chip server-side">server</span></span>
+            </li>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Fix for #130, tracked + closed in M2">✓</span>
+              <span class="issue-num">#132</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/132">Fix mining: enforce range continuously, not just at start (#130)</a>
+              <span class="issue-labels"><span class="chip server-side">server</span></span>
+            </li>
             <li class="issue closed">
               <span class="issue-state closed" title="Closed via PR #137">✓</span>
               <span class="issue-num">#123</span>
@@ -820,22 +845,10 @@
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/124">Reshape stdb/utils.rs around domain queries (house the validate-on-read)</a>
               <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip in-050">on main · #137</span></span>
             </li>
-            <li class="issue open">
-              <span class="issue-state open" title="open">○</span>
-              <span class="issue-num">#102</span>
-              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/102">Persistence smoke test: stations + contributions survive server restart</a>
-              <span class="issue-labels"><span class="chip documentation">docs</span><span class="chip server-side">server</span></span>
-            </li>
-            <li class="issue open">
-              <span class="issue-state open">○</span>
-              <span class="issue-num">#101</span>
-              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/101">ServerMessage notification scopes (personal/faction/system) + priorities</a>
-              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip server-side">server</span></span>
-            </li>
             <li class="issue closed">
               <span class="issue-state closed" title="Closed via PR #136">✓</span>
               <span class="issue-num">#100</span>
-              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/100">Welcome-back panel: client-side rendering of the welcome-back ServerMessage</a>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/100">Welcome-back panel: client-side rendering of the welcome-back message</a>
               <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip in-050">on main · #136</span></span>
             </li>
             <li class="issue closed">
@@ -848,10 +861,10 @@
         </article>
 
         <!-- ============ M3 ============ -->
-        <article class="ms pending" id="m3" data-progress="0">
+        <article class="ms active" id="m3" data-progress="0">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M3</span>Two-Faction MVP Setup 🪐</h3>
-            <span class="ms-status pending">Pending · 0/5</span>
+            <span class="ms-status active">● Up next · 0/5</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
@@ -899,7 +912,7 @@
         <article class="ms pending" id="m4" data-progress="0">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M4</span>Multi-Sector World Buildout 🌌</h3>
-            <span class="ms-status pending">Pending · 0/6</span>
+            <span class="ms-status pending">Pending · 0/7</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
@@ -907,9 +920,15 @@
           </div>
           <div class="progress">
             <div class="progress-track"><div class="progress-fill" data-fill="0"></div></div>
-            <div class="progress-label">0% · 6 open</div>
+            <div class="progress-label">0% · 7 open</div>
           </div>
           <ul class="issues">
+            <li class="issue open">
+              <span class="issue-state open">○</span>
+              <span class="issue-num">#145</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/145">Server-admin client: galaxy overview + invoking admin reducers the CLI can't</a>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip server-side">server</span></span>
+            </li>
             <li class="issue open">
               <span class="issue-state open">○</span>
               <span class="issue-num">#120</span>
@@ -950,31 +969,43 @@
         </article>
 
         <!-- ============ M5 ============ -->
-        <article class="ms pending" id="m5" data-progress="0">
+        <article class="ms pending" id="m5" data-progress="20">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M5</span>Mining Loop + Polish ⛏️</h3>
-            <span class="ms-status pending">Pending · 0/8</span>
+            <span class="ms-status pending">Pending · 2/10</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
             Mining end-to-end: target asteroid, mine ~15 min, cargo populates, haul to construction site. Mining visual effects broadcast to all clients in sector. Cozy polish pass. <em>20-minute session feels good.</em>
           </div>
           <div class="progress">
-            <div class="progress-track"><div class="progress-fill" data-fill="0"></div></div>
-            <div class="progress-label">0% · 8 open · #128 and #130 fixed on main (issues pending close)</div>
+            <div class="progress-track"><div class="progress-fill" data-fill="20"></div></div>
+            <div class="progress-label">20% · 2 closed · 8 open</div>
           </div>
           <ul class="issues">
             <li class="issue open">
-              <span class="issue-state open" title="open — fix landed but issue still open">○</span>
-              <span class="issue-num">#130</span>
-              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/130">Mining continues from anywhere in-sector — range is only checked at start</a>
-              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip in-050">fix on main · #132</span></span>
+              <span class="issue-state open" title="Filed during the #101 playtest">○</span>
+              <span class="issue-num">#144</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/144">Cargo crate pickup: no client UI to invoke the reducer</a>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip agent-eligible">agent-ready</span></span>
             </li>
             <li class="issue open">
-              <span class="issue-state open" title="open — fix landed but issue still open">○</span>
+              <span class="issue-state open" title="open">○</span>
+              <span class="issue-num">#141</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/141">Mining state desync on reconnect: client shows idle but ship keeps accruing ore</a>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip client-side">client</span><span class="chip server-side">server</span></span>
+            </li>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed — fix #132 on main">✓</span>
+              <span class="issue-num">#130</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/130">Mining continues from anywhere in-sector — range is only checked at start</a>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip in-050">fixed · #132</span></span>
+            </li>
+            <li class="issue closed">
+              <span class="issue-state closed" title="Closed — fix #131 on main">✓</span>
               <span class="issue-num">#128</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/128">Asteroids no longer spawn — seed fields fully at init + hourly maintenance cadence</a>
-              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip in-050">fix on main · #131</span></span>
+              <span class="issue-labels"><span class="chip bug">bug</span><span class="chip server-side">server</span><span class="chip in-050">fixed · #131</span></span>
             </li>
             <li class="issue open">
               <span class="issue-state open">○</span>
@@ -1049,17 +1080,29 @@
         <article class="ms pending" id="m7" data-progress="0">
           <div class="ms-head">
             <h3 class="ms-title"><span class="tag">M7</span>Anti-Cheat Hardening via Views 🛡️</h3>
-            <span class="ms-status pending">Pending · 0/2</span>
+            <span class="ms-status pending">Pending · 0/5</span>
           </div>
           <div class="ms-exit">
             <span class="lbl">Exit gate</span>
-            First post-MVP work. Convert ship/asteroid/cargo/visual-effect/stellar-object tables from <code>public</code> to private, expose via per-sector Views. Refactor Stations to use Views instead of RLS. <em>Foundation for protecting client-visible state from cheaters.</em>
+            First post-MVP work. Convert ship/asteroid/cargo/visual-effect/stellar-object tables from <code>public</code> to private, expose via per-sector Views. Refactor Stations to use Views instead of RLS. <em>Foundation for protecting client-visible state from cheaters.</em> The messaging redesign (#101 → PR #143) already piloted the private-table + Views pattern — M7 extends it to world state.
           </div>
           <div class="progress">
             <div class="progress-track"><div class="progress-fill" data-fill="0"></div></div>
-            <div class="progress-label">0% · 2 open</div>
+            <div class="progress-label">0% · 5 open</div>
           </div>
           <ul class="issues">
+            <li class="issue open">
+              <span class="issue-state open">○</span>
+              <span class="issue-num">#138</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/138">Spike: investigate a separate SpacetimeDB module for player accounts (cross-module comms)</a>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip server-side">server</span><span class="chip agent-eligible">agent-ready</span><span class="chip future-vision">future-vision</span></span>
+            </li>
+            <li class="issue open">
+              <span class="issue-state open">○</span>
+              <span class="issue-num">#134</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/134">Spike: drive the WASM client with chrome-devtools-mcp for agent iteration</a>
+              <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip client-side">client</span><span class="chip future-vision">future-vision</span></span>
+            </li>
             <li class="issue open">
               <span class="issue-state open">○</span>
               <span class="issue-num">#95</span>
@@ -1071,6 +1114,12 @@
               <span class="issue-num">#84</span>
               <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/84">Per-sector visibility scoping via SpacetimeDB views</a>
               <span class="issue-labels"><span class="chip enhancement">enhancement</span><span class="chip server-side">server</span><span class="chip agent-human-needed">human-needed</span></span>
+            </li>
+            <li class="issue open">
+              <span class="issue-state open">○</span>
+              <span class="issue-num">#50</span>
+              <a class="issue-title" href="https://github.com/GalaxyCr8r/solarance-beginnings/issues/50">Actually implement client-side subscriptions if RLS still hasn't been fixed</a>
+              <span class="issue-labels"><span class="chip client-side">client</span></span>
             </li>
           </ul>
         </article>
@@ -1155,7 +1204,7 @@
 
     <footer>
       <img class="footer-mark" src="../assets/Solarance_Icon.png" alt="Solarance" />
-      Milestones snapshot · 2026-06-04 · Solarance: Beginnings · Source:
+      Milestones snapshot · 2026-06-10 · Solarance: Beginnings · Source:
       <a href="https://github.com/GalaxyCr8r/solarance-beginnings/milestones">github.com/GalaxyCr8r/solarance-beginnings/milestones</a>
     </footer>
 

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -6,7 +6,7 @@ use solarance_shared::Vec2;
 
 use crate::{
     definitions::{
-        factions::FACTION_LRAK_COMBINE,
+        factions::{FACTION_LRAK_COMBINE, FACTION_REDIAR_FEDERATION},
         item_types::{ITEM_IRON_ORE, ITEM_SILICON_ORE},
     },
     logic::sectors::asteroid_fields::fill_asteroid_sector,
@@ -35,12 +35,15 @@ pub fn init(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
 
 fn demo_sectors(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     let faction_lrak = FactionId::new(FACTION_LRAK_COMBINE);
+    let faction_rediar = FactionId::new(FACTION_REDIAR_FEDERATION);
     let procyon = create_procyon_star_system(dsl, &faction_lrak)?;
     let (alpha, beta, gamma) = create_procyon_sectors(dsl, &procyon, &faction_lrak)?;
+    let delta = create_rediar_sector(dsl, &procyon, &faction_rediar)?;
 
-    setup_sector_connections(dsl, &alpha, &beta, &gamma)?;
+    setup_sector_connections(dsl, &alpha, &beta, &gamma, &delta)?;
     populate_sectors_with_asteroids(dsl, &alpha, &beta)?;
     create_sector_stations(dsl, &alpha, &beta, &gamma, &faction_lrak)?;
+    create_delta_capital_station(dsl, &delta, &faction_rediar)?;
     Ok(())
 }
 
@@ -162,15 +165,45 @@ fn create_procyon_sectors(
     Ok((alpha, beta, gamma))
 }
 
+/// Creates the Rediar Federation home sector (#105). Sits on the far side of
+/// the system from Lrak's Homeworld Sector so the two capitals bracket the
+/// neutral middle sectors.
+fn create_rediar_sector(
+    dsl: &DSL<'_, ReducerContext>,
+    procyon: &StarSystem,
+    faction_rediar: &FactionId,
+) -> Result<Sector, String> {
+    let delta = dsl.create_sector(CreateSector {
+        id: 3,
+        system_id: procyon.get_id(),
+        name: "Federation Prime Sector".to_string(),
+        description: None,
+        controlling_faction_id: faction_rediar.clone(),
+        security_level: 10,
+        sunlight: 0.8,
+        anomalous: 0.1,
+        nebula: 0.2,
+        rare_ore: 0.1,
+        x: -120.0,
+        y: 8.0,
+        background_gfx_key: None,
+    })?;
+    Ok(delta)
+}
+
 /// Sets up warp gate connections between sectors
 fn setup_sector_connections(
     dsl: &DSL<'_, ReducerContext>,
     alpha: &Sector,
     beta: &Sector,
     gamma: &Sector,
+    delta: &Sector,
 ) -> Result<(), String> {
     connect_sectors_with_warpgates(dsl, alpha, beta)?;
     connect_sectors_with_warpgates(dsl, beta, gamma)?;
+    // Rediar's capital connects through Alpha — both faction capitals sit two
+    // jumps apart with the neutral sectors between them.
+    connect_sectors_with_warpgates(dsl, delta, alpha)?;
     Ok(())
 }
 
@@ -311,6 +344,35 @@ fn create_gamma_capital_station(
     )?;
 
     let mut faction = dsl.get_faction_by_id(faction_id)?;
+    faction.set_capital_station_id(Some(station.get_id().value()));
+
+    dsl.update_faction_by_id(faction)?;
+
+    Ok(())
+}
+
+/// Creates the Rediar Federation capital station in Federation Prime Sector
+/// and stamps it as the faction's Capital — the spawn anchor for new Rediar
+/// players (#105).
+fn create_delta_capital_station(
+    dsl: &DSL<'_, ReducerContext>,
+    delta: &Sector,
+    faction_rediar: &FactionId,
+) -> Result<(), String> {
+    let station = create_station_with_modules(
+        dsl,
+        StationSize::Capital,
+        delta,
+        &create_sobj(dsl, StellarObjectKinds::Station, &delta.get_id())?,
+        faction_rediar.clone(),
+        "Federation Prime",
+        None,
+        Vec2::new(-455.0, 1337.0),
+        0.0,
+        vec![create_trading_module()],
+    )?;
+
+    let mut faction = dsl.get_faction_by_id(faction_rediar)?;
     faction.set_capital_station_id(Some(station.get_id().value()));
 
     dsl.update_faction_by_id(faction)?;

--- a/server/src/logic/ships/creation.rs
+++ b/server/src/logic/ships/creation.rs
@@ -11,7 +11,7 @@ use crate::{
         stellarobjects::stellar_object_creation::create_sobj,
     },
     tables::{
-        factions::FactionId,
+        factions::*,
         items::*,
         players::*,
         sectors::SectorId,
@@ -25,10 +25,54 @@ use crate::{
 ///////////////////////////////////
 ///  Reducers
 
-/// Default starting pose for a freshly-registered player ship. Eventually
-/// chosen from the joinable faction's home station.
+/// Fallback spawn pose for players whose faction has no Capital station
+/// (e.g. Factionless). Factions *with* a Capital spawn beside it instead —
+/// see [`capital_spawn_for_faction`].
 const STARTING_SPAWN_POS: Vec2 = Vec2 { x: 64.0, y: 64.0 };
 const STARTING_SPAWN_ROTATION: f32 = 0.0;
+const FALLBACK_SPAWN_SECTOR: u64 = 0;
+
+/// Offset from the Capital station's position so new ships don't spawn inside
+/// the station sprite.
+const CAPITAL_SPAWN_OFFSET: Vec2 = Vec2 { x: 400.0, y: 250.0 };
+
+/// Resolve where a new player's ship should spawn: their faction's Capital
+/// station's sector, right beside the station (#105). Falls back to the
+/// default sector/pose when the faction has no Capital (Factionless) or the
+/// Capital row is missing — a wrong-but-playable spawn beats a failed one.
+fn capital_spawn_for_faction(
+    dsl: &DSL<'_, ReducerContext>,
+    faction_id: &FactionId,
+) -> (SectorId, Vec2) {
+    let fallback = (SectorId::new(FALLBACK_SPAWN_SECTOR), STARTING_SPAWN_POS);
+
+    let faction = match dsl.get_faction_by_id(faction_id) {
+        Ok(f) => f,
+        Err(_) => return fallback,
+    };
+    let station_id = match faction.get_capital_station_id() {
+        Some(id) => StationId::new(*id),
+        None => return fallback,
+    };
+    match dsl.get_station_by_id(&station_id) {
+        Ok(station) => (
+            SectorId::new(station.get_sector_id().value()),
+            Vec2 {
+                x: station.get_position().x + CAPITAL_SPAWN_OFFSET.x,
+                y: station.get_position().y + CAPITAL_SPAWN_OFFSET.y,
+            },
+        ),
+        Err(_) => {
+            log::warn!(
+                "Faction {} names capital station {} but the station row is missing; spawning at fallback sector {}",
+                faction_id.value(),
+                station_id.value(),
+                FALLBACK_SPAWN_SECTOR
+            );
+            fallback
+        }
+    }
+}
 
 /// Creates a new ship for a registered player with starting equipment and cargo.
 /// Sets up the ship's stellar object, controller, and initial inventory.
@@ -56,22 +100,29 @@ pub fn create_player_controlled_ship(
         }
     };
 
-    if let Ok(sobj) = create_sobj(
-        &dsl,
-        StellarObjectKinds::Ship,
-        &SectorId::new(0), // TODO: Make this the proper sector id! Needs to be picked based on the joinable faction's home station.
-    ) {
+    // One ship per player (#103). The client only offers ship creation when
+    // no ship exists, but the reducer must hold the line on its own.
+    if dsl.get_ships_by_player_id(&player_id).next().is_some() {
+        return Err(format!(
+            "Player {} already owns a ship — one Column per player in MVP (#103); rejecting create_player_controlled_ship",
+            username
+        ));
+    }
+
+    let faction_id = player.get_faction_id().clone();
+    let (spawn_sector, spawn_pos) = capital_spawn_for_faction(&dsl, &faction_id);
+
+    if let Ok(sobj) = create_sobj(&dsl, StellarObjectKinds::Ship, &spawn_sector) {
         initialize_controller_for_player(&dsl, &player_id, &sobj)?;
 
         let ship_type = dsl.get_ship_type_definition_by_id(ShipTypeDefinitionId::new(1001))?;
-        let faction_id = player.get_faction_id().clone();
         let (ship, mut status) = create_ship_from_sobj(
             &dsl,
             &ship_type,
             &player_id,
             &faction_id,
             &sobj,
-            STARTING_SPAWN_POS,
+            spawn_pos,
             STARTING_SPAWN_ROTATION,
         )?;
 


### PR DESCRIPTION
Part of M3 (Two-Faction MVP Setup). Addresses #105. Closes #103 (the one-ship guard below was its only missing piece). Also carries the refreshed milestones report (M2 complete, M3 active).

## Summary

- **Rediar capital seeded (#105):** new "Federation Prime Sector" (id 3, Rediar-controlled, security 10) with a Capital-class "Federation Prime" station; `faction.capital_station_id` stamped, mirroring Lrak's Homeworld City in Gamma. Warpgate-connected to Alpha so both capitals sit two jumps apart around the neutral middle.
- **Spawn-at-capital (#105):** `create_player_controlled_ship` resolves the player's faction → capital station → sector + position, and spawns the ship beside the station (400, 250 offset). Replaces the hardcoded `SectorId::new(0)` TODO. Factionless / missing-capital falls back to the old sector-0 pose with a warn log (wrong-but-playable beats failed).
- **One-ship-per-player (#103):** the reducer now rejects creation when the player already owns a ship. Column-only was already structural — the reducer takes no ship-type argument and hardcodes type 1001 — so this guard was the only missing enforcement.

## Test plan

- [x] `task server:build` clean
- [x] `--clear-database` republish, register a Lrak player → spawns in Homeworld Sector beside Homeworld City
- [x] Register a Rediar player → spawns in Federation Prime Sector beside Federation Prime
- [x] Jumpgate path Delta ↔ Alpha works in both directions
- [x] Second `create_player_controlled_ship` call for the same player is rejected with a clear error

**Breaking seed change** — needs `task server:publish-clear` (new sector/station rows at init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
