### PR TITLE
M3: Faction picker hard-cap — capital-holding factions only (#93)

### DIFF
--- a/client/src/gameplay/gui.rs
+++ b/client/src/gameplay/gui.rs
@@ -12,3 +12,16 @@ pub mod out_of_play_screen;
 pub mod ship_details_window;
 pub mod status_widget;
 pub mod welcome_back_widget;
+
+/// Display color for a faction (Lrak red, Rediar blue — CONTEXT.md §3).
+/// Faction colors are a design commitment but are not stored in the Faction
+/// table, so the canonical id → color mapping lives here for every window
+/// that tints by faction (creation picker, construction sites, map, …).
+/// Unknown / colorless factions render light gray.
+pub fn faction_color(faction_id: u32) -> egui::Color32 {
+    match faction_id {
+        1 => egui::Color32::from_rgb(230, 90, 90), // Lrak Combine — red
+        4 => egui::Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        _ => egui::Color32::LIGHT_GRAY,
+    }
+}

--- a/client/src/gameplay/gui.rs
+++ b/client/src/gameplay/gui.rs
@@ -13,6 +13,14 @@ pub mod ship_details_window;
 pub mod status_widget;
 pub mod welcome_back_widget;
 
+// Factions
+pub const FACTION_FACTIONLESS: u32 = 0;
+pub const FACTION_LRAK_COMBINE: u32 = 1;
+pub const FACTION_INDEPENDENT_WORLDS_ALLIANCE: u32 = 2;
+pub const FACTION_FREE_TRADE_UNION: u32 = 3;
+pub const FACTION_REDIAR_FEDERATION: u32 = 4;
+pub const FACTION_VANCELLAN: u32 = 5;
+
 /// Display color for a faction (Lrak red, Rediar blue — CONTEXT.md §3).
 /// Faction colors are a design commitment but are not stored in the Faction
 /// table, so the canonical id → color mapping lives here for every window
@@ -20,8 +28,11 @@ pub mod welcome_back_widget;
 /// Unknown / colorless factions render light gray.
 pub fn faction_color(faction_id: u32) -> egui::Color32 {
     match faction_id {
-        1 => egui::Color32::from_rgb(230, 90, 90), // Lrak Combine — red
-        4 => egui::Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        FACTION_LRAK_COMBINE => egui::Color32::from_rgb(230, 90, 90), // Lrak Combine — red
+        FACTION_INDEPENDENT_WORLDS_ALLIANCE => egui::Color32::from_rgb(90, 230, 90), // IWA - green
+        FACTION_FREE_TRADE_UNION => egui::Color32::ORANGE,
+        FACTION_REDIAR_FEDERATION => egui::Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        FACTION_VANCELLAN => egui::Color32::MAGENTA,
         _ => egui::Color32::LIGHT_GRAY,
     }
 }

--- a/client/src/gameplay/gui/creation_window.rs
+++ b/client/src/gameplay/gui/creation_window.rs
@@ -117,20 +117,6 @@ fn create_ship(
     }
 }
 
-/// Display color for a faction's picker entry. Faction colors are a design
-/// commitment (CONTEXT.md §3: Lrak / red, Rediar / blue) but are not stored
-/// in the Faction table, so the mapping lives here.
-fn faction_color(faction_id: u32, pickable: bool) -> Color32 {
-    if !pickable {
-        return Color32::DARK_GRAY;
-    }
-    match faction_id {
-        1 => Color32::from_rgb(230, 90, 90),  // Lrak Combine — red
-        4 => Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
-        _ => Color32::LIGHT_GRAY,
-    }
-}
-
 fn create_player(ctx: &DbConnection, game_state: &mut GameState<'_>, ui: &mut egui::Ui) {
     // Create an account
     ui.heading("Player Creation");
@@ -170,7 +156,12 @@ fn create_player(ctx: &DbConnection, game_state: &mut GameState<'_>, ui: &mut eg
             // Combine and Rediar Federation.
             let pickable = faction.capital_station_id.is_some();
 
-            let label = RichText::new(&faction.name).color(faction_color(faction.id, pickable));
+            let color = if pickable {
+                crate::gameplay::gui::faction_color(faction.id)
+            } else {
+                Color32::DARK_GRAY
+            };
+            let label = RichText::new(&faction.name).color(color);
             let response =
                 ui.add_enabled(pickable, egui::SelectableLabel::new(is_selected, label));
             if response.clicked() {

--- a/client/src/gameplay/gui/creation_window.rs
+++ b/client/src/gameplay/gui/creation_window.rs
@@ -117,6 +117,20 @@ fn create_ship(
     }
 }
 
+/// Display color for a faction's picker entry. Faction colors are a design
+/// commitment (CONTEXT.md §3: Lrak / red, Rediar / blue) but are not stored
+/// in the Faction table, so the mapping lives here.
+fn faction_color(faction_id: u32, pickable: bool) -> Color32 {
+    if !pickable {
+        return Color32::DARK_GRAY;
+    }
+    match faction_id {
+        1 => Color32::from_rgb(230, 90, 90),  // Lrak Combine — red
+        4 => Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        _ => Color32::LIGHT_GRAY,
+    }
+}
+
 fn create_player(ctx: &DbConnection, game_state: &mut GameState<'_>, ui: &mut egui::Ui) {
     // Create an account
     ui.heading("Player Creation");
@@ -150,8 +164,22 @@ fn create_player(ctx: &DbConnection, game_state: &mut GameState<'_>, ui: &mut eg
         for faction in &joinable_factions {
             let is_selected = game_state.creation_window.selected_faction_id == Some(faction.id);
 
-            if ui.selectable_label(is_selected, &faction.name).clicked() {
+            // Only factions with a Capital station are pickable (#93) — new
+            // players spawn at their faction's Capital, so a faction without
+            // one has nowhere to put them. In MVP that is exactly Lrak
+            // Combine and Rediar Federation.
+            let pickable = faction.capital_station_id.is_some();
+
+            let label = RichText::new(&faction.name).color(faction_color(faction.id, pickable));
+            let response =
+                ui.add_enabled(pickable, egui::SelectableLabel::new(is_selected, label));
+            if response.clicked() {
                 game_state.creation_window.selected_faction_id = Some(faction.id);
+            }
+            if !pickable {
+                response.on_disabled_hover_text(
+                    "This faction has no Capital station yet — not joinable in the MVP.",
+                );
             }
 
             if is_selected {

--- a/server/src/logic/players/registration.rs
+++ b/server/src/logic/players/registration.rs
@@ -3,7 +3,7 @@ use spacetimedsl::*;
 
 use crate::definitions::factions::FACTION_FACTIONLESS;
 use crate::tables::{
-    factions::FactionId,
+    factions::*,
     messages::{post_faction_channel, MessageSender},
 };
 
@@ -48,13 +48,37 @@ pub fn register_playername(
         return Err("Username already taken!".to_string());
     }
 
-    // TODO: Re-enable faction validation once client bindings are updated
-    // For now, just use the provided faction_id or default to factionless
+    // Faction validation (#93): the chosen faction must exist, be joinable,
+    // and have a Capital station — new players spawn at their faction's
+    // Capital (#105), so a faction without one has nowhere to put them. In
+    // MVP this admits exactly Lrak Combine and Rediar Federation; the picker
+    // greys everything else out, and this is the server-side backstop.
     let final_faction = FactionId::new(if faction_id == 0 {
         FACTION_FACTIONLESS
     } else {
         faction_id
     });
+    let faction = dsl.get_faction_by_id(&final_faction).map_err(|_| {
+        format!(
+            "Registration rejected: faction id {} does not exist (player identity {})",
+            final_faction.value(),
+            identity
+        )
+    })?;
+    if !faction.get_joinable() {
+        return Err(format!(
+            "Registration rejected: faction '{}' (id {}) is not joinable",
+            faction.get_name(),
+            final_faction.value()
+        ));
+    }
+    if faction.get_capital_station_id().is_none() {
+        return Err(format!(
+            "Registration rejected: faction '{}' (id {}) has no Capital station to spawn at — only capital-holding factions are joinable in MVP (#93)",
+            faction.get_name(),
+            final_faction.value()
+        ));
+    }
 
     let player = dsl.create_player(CreatePlayer {
         id: identity,


### PR DESCRIPTION
Closes #93. Part of M3 (Two-Faction MVP Setup).

## Summary

- **Client (`creation_window.rs`):** faction picker buttons are enabled only for factions whose `capital_station_id` is set — per the M3 decision, "has a Capital station" *is* the joinability criterion, so the cap to Lrak Combine + Rediar Federation is data-driven rather than a hardcoded id list. Other joinable factions (Factionless, IWA, FTU) stay visible but greyed out with a hover explanation; their table rows are untouched. Lrak renders red, Rediar blue (colors hardcoded client-side — the Faction table has no color column).
- **Server (`registration.rs`):** `register_playername` now validates the chosen faction exists, is joinable, and holds a Capital station — replacing the long-standing disabled-validation TODO. This is the backstop behind the picker, and it matters because new players spawn at their faction's Capital (#105 / PR #146).

## Interaction with PR #146

Independent code, dependent data: on current `main` only Lrak has a capital, so until #146 (Rediar capital seed) merges and the DB is reseeded, **only Lrak is pickable**. Merge #146 first (or together) and `publish-clear` to get both factions live.

## Test plan

- [x] `task server:build` clean
- [x] client `cargo build` clean
- [x] Picker shows Lrak red / Rediar blue as clickable; Factionless/IWA/FTU greyed with tooltip
- [x] Registering with a greyed faction id via raw reducer call is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)