### PR TITLE
M3: Faction-flag UI for construction sites (#104)

### DIFF
--- a/client/src/gameplay/gui.rs
+++ b/client/src/gameplay/gui.rs
@@ -12,3 +12,16 @@ pub mod out_of_play_screen;
 pub mod ship_details_window;
 pub mod status_widget;
 pub mod welcome_back_widget;
+
+/// Display color for a faction (Lrak red, Rediar blue — CONTEXT.md §3).
+/// Faction colors are a design commitment but are not stored in the Faction
+/// table, so the canonical id → color mapping lives here for every window
+/// that tints by faction (creation picker, construction sites, map, …).
+/// Unknown / colorless factions render light gray.
+pub fn faction_color(faction_id: u32) -> egui::Color32 {
+    match faction_id {
+        1 => egui::Color32::from_rgb(230, 90, 90), // Lrak Combine — red
+        4 => egui::Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        _ => egui::Color32::LIGHT_GRAY,
+    }
+}

--- a/client/src/gameplay/gui/construction_window.rs
+++ b/client/src/gameplay/gui/construction_window.rs
@@ -71,18 +71,6 @@ fn nearest_construction_site(ctx: &DbConnection) -> Option<(Station, StationUnde
     best.map(|(s, u, _)| (s, u))
 }
 
-/// Display color for a faction (Lrak red, Rediar blue — CONTEXT.md §3).
-/// Faction colors are not stored in the Faction table, so the mapping lives
-/// client-side. (A copy exists in `creation_window.rs` from #93; consolidate
-/// into `stdb/utils.rs` when a third caller appears.)
-fn faction_color(faction_id: u32) -> Color32 {
-    match faction_id {
-        1 => Color32::from_rgb(230, 90, 90),   // Lrak Combine — red
-        4 => Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
-        _ => Color32::LIGHT_GRAY,
-    }
-}
-
 fn draw_site(
     ui: &mut egui::Ui,
     ctx: &DbConnection,
@@ -95,7 +83,7 @@ fn draw_site(
     let own_faction_id = get_current_player(ctx).map(|p| p.faction_id.value);
     let is_own = own_faction_id == Some(station.owner_faction_id);
     let heading_color = if is_own {
-        faction_color(station.owner_faction_id)
+        crate::gameplay::gui::faction_color(station.owner_faction_id)
     } else {
         Color32::GRAY
     };

--- a/client/src/gameplay/gui/construction_window.rs
+++ b/client/src/gameplay/gui/construction_window.rs
@@ -71,13 +71,48 @@ fn nearest_construction_site(ctx: &DbConnection) -> Option<(Station, StationUnde
     best.map(|(s, u, _)| (s, u))
 }
 
+/// Display color for a faction (Lrak red, Rediar blue — CONTEXT.md §3).
+/// Faction colors are not stored in the Faction table, so the mapping lives
+/// client-side. (A copy exists in `creation_window.rs` from #93; consolidate
+/// into `stdb/utils.rs` when a third caller appears.)
+fn faction_color(faction_id: u32) -> Color32 {
+    match faction_id {
+        1 => Color32::from_rgb(230, 90, 90),   // Lrak Combine — red
+        4 => Color32::from_rgb(100, 150, 255), // Rediar Federation — blue
+        _ => Color32::LIGHT_GRAY,
+    }
+}
+
 fn draw_site(
     ui: &mut egui::Ui,
     ctx: &DbConnection,
     station: &Station,
     under_construction: &StationUnderConstruction,
 ) {
-    ui.heading(station_display_name(ctx, station));
+    // Faction-flag affordance (#104): own-faction sites carry the faction's
+    // color and a "(your faction)" tag; other factions' sites render muted.
+    // Contribution stays open to everyone — this is emphasis, not a gate.
+    let own_faction_id = get_current_player(ctx).map(|p| p.faction_id.value);
+    let is_own = own_faction_id == Some(station.owner_faction_id);
+    let heading_color = if is_own {
+        faction_color(station.owner_faction_id)
+    } else {
+        Color32::GRAY
+    };
+
+    ui.horizontal(|ui| {
+        ui.heading(RichText::new(station_display_name(ctx, station)).color(heading_color));
+        if is_own {
+            ui.label(
+                RichText::new("(your faction)")
+                    .color(heading_color)
+                    .small(),
+            );
+        }
+    });
+    if let Some(faction) = ctx.db().faction().id().find(&station.owner_faction_id) {
+        ui.small(format!("Owned by {}", faction.name));
+    }
     ui.separator();
 
     if under_construction.is_operational {

--- a/server/src/logic/players/welcome_back.rs
+++ b/server/src/logic/players/welcome_back.rs
@@ -34,7 +34,7 @@ use spacetimedsl::*;
 // Glob-import the table modules whose generated DSL extension traits we call —
 // the per-table `Get*` traits must be in scope, not just the row/ID types.
 use crate::tables::{
-    items::*, messages::send_direct_server_info, players::Player, ships::*, stations::*,
+    items::*, messages::send_direct_server_info, players::Player, sectors::GetSectorRowOptionById, ships::*, stations::*
 };
 
 /// Compose and deliver the welcome-back `DirectServerMessage` for `player`.
@@ -86,12 +86,17 @@ fn compose_construction_summary<T: spacetimedsl::WriteContext>(
             Ok(s) => s,
             Err(_) => continue, // Station row gone; skip rather than bail.
         };
+        let sector = match dsl.get_sector_by_id(station.get_sector_id()){
+            Ok(s) => s,
+            Err(_) => continue, // Sector row gone, somehow; skip rather than bail.
+        };
         let progress = *uc.get_construction_progress_percentage();
         let is_own = station.get_owner_faction_id().value() == own_faction;
         let flag = if is_own { " (your faction)" } else { "" };
         let line = format!(
-            "  • {} — {:.0}% complete{}",
+            "  • {} in {} — {:.0}% complete{}",
             station.get_name(),
+            sector.get_name(),
             progress,
             flag
         );

--- a/server/src/logic/players/welcome_back.rs
+++ b/server/src/logic/players/welcome_back.rs
@@ -68,14 +68,16 @@ pub fn send_welcome_back_message<T: spacetimedsl::WriteContext>(
     send_direct_server_info(dsl, &player.get_id(), lines.join("\n"))
 }
 
-/// One line per construction site still under way, own-faction sites flagged.
+/// One line per construction site still under way — own-faction sites flagged
+/// and listed first (#104).
 fn compose_construction_summary<T: spacetimedsl::WriteContext>(
     dsl: &DSL<T>,
     player: &Player,
 ) -> String {
     let own_faction = player.faction_id.value();
 
-    let mut site_lines: Vec<String> = Vec::new();
+    let mut own_lines: Vec<String> = Vec::new();
+    let mut other_lines: Vec<String> = Vec::new();
     for uc in dsl.get_all_stations_under_construction() {
         if *uc.get_is_operational() {
             continue; // Already finished — not "under construction" any more.
@@ -85,18 +87,23 @@ fn compose_construction_summary<T: spacetimedsl::WriteContext>(
             Err(_) => continue, // Station row gone; skip rather than bail.
         };
         let progress = *uc.get_construction_progress_percentage();
-        let flag = if station.get_owner_faction_id().value() == own_faction {
-            " (your faction)"
-        } else {
-            ""
-        };
-        site_lines.push(format!(
+        let is_own = station.get_owner_faction_id().value() == own_faction;
+        let flag = if is_own { " (your faction)" } else { "" };
+        let line = format!(
             "  • {} — {:.0}% complete{}",
             station.get_name(),
             progress,
             flag
-        ));
+        );
+        if is_own {
+            own_lines.push(line);
+        } else {
+            other_lines.push(line);
+        }
     }
+
+    let mut site_lines = own_lines;
+    site_lines.extend(other_lines);
 
     if site_lines.is_empty() {
         "No construction sites are active right now.".to_string()


### PR DESCRIPTION
Closes #104. Part of M3 (Two-Faction MVP Setup).

## Summary

- **Construction window:** the nearest-site heading renders in the owning faction's color (Lrak red / Rediar blue) with a small "(your faction)" tag when it's the player's own faction; other factions' sites render muted gray. A new "Owned by <faction>" line names the owner either way. Deposit buttons unchanged — contribution stays open to all per the M3 soft-default.
- **Welcome-back summary (server):** own-faction sites are listed before other factions' sites; the "(your faction)" text flag already existed.

## Notes

- `faction_color` is a small local helper duplicated from PR #147's `creation_window.rs` copy (both branched off the same main). Consolidate into `stdb/utils.rs` when a third caller appears — flagged in a comment at both sites.
- Verification scenario "a Lrak player can tell Lrak sites from Rediar sites" needs PR #146's Rediar seed merged + `publish-clear` to actually have two factions' sites in the world.

## Test plan

- [x] `task server:build` clean
- [x] client `cargo build` clean
- [ ] Own-faction site heading shows faction color + "(your faction)"; other-faction site shows muted gray + "Owned by …"
- [ ] Welcome-back lists own-faction sites first

🤖 Generated with [Claude Code](https://claude.com/claude-code)