### PR TITLE
docs: ADR-0002 — docking exits the sector simulation; Piloted vs Docked Ship glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,10 @@ Strict hierarchical containers for the game world.
 
 ## 3. Player & Entities (Nouns)
 *   **Player / Client:** The human interacting with the game. Designed around "David" (intermittent play, requires pause-able progression).
-*   **Ship:** The player's avatar. In MVP, this is strictly a jack-of-all-trades **Corvette**. 
+*   **Ship:** The player's avatar. In MVP, this is strictly a jack-of-all-trades **Corvette**. A Ship is always in exactly one of two states — say which one you mean (see ADR-0002):
+    *   **Piloted Ship:** `location == Sector`. Has a `StellarObject` + `MovementState`; the **only** kind of ship the sector simulation (movement, dead-reckoning, sector subscriptions, range checks, HUD/minimap) can see. *(Code: `get_player_ship` returns this — `None` while docked.)*
+    *   **Docked Ship:** `location == Station`. Its `StellarObject` is **deleted** on dock (`sobj_id` is a `0` sentinel — not a FK); cargo/status/equipment persist on the `Ship` row. Invisible to all sector-scoped queries; reachable only via the `Ship` table by player/station id.
+    *   *Avoid:* the bare phrase "the player's ship" in code or issues — it hides the piloted-vs-owned distinction that caused #149. UI that should always show (welcome-back, assets, notifications) must gate on **ownership**, not on a Piloted Ship existing.
 *   **Faction:** A team identifier. In MVP, strictly limited to a string name and a color (`Lrak Combine` / Red, `Rediar Federation` / Blue). Determines which Stations a player can `Contribute` to.
 *   **Contribution Pool:** The required list of resources a Station or Module needs to reach the next growth stage. 
 *   **Welcome-Back Summary:** A text-only data payload delivered to the client upon login, detailing offline ticks, station progress, and personal asset state. *(Code: `WelcomeBackPayload`, `OfflineTickCalculator`)*

--- a/docs/adr/0002-docking-removes-ship-from-sector-simulation.md
+++ b/docs/adr/0002-docking-removes-ship-from-sector-simulation.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+date: 2026-06-12
+prompted-by: "#149"
+---
+
+# Docking removes the ship from the sector simulation
+
+## Context
+
+When a ship docks (`dock_to_station`, `server/src/logic/ships/station_interactions.rs`), its `StellarObject` row is **deleted**, its movement snapshot is zeroed, `Ship.location` flips to `Station`, and `Ship.sobj_id` is set to the sentinel `0`. Undocking creates a brand-new `StellarObject` at the station's sector. A docked ship therefore has no position, no movement state, and no presence in any sector-scoped query — only its `Ship` row (cargo, status, equipment) persists.
+
+## Decision
+
+A docked ship **exits the sector simulation entirely**. "The player's ship" is consequently an ambiguous phrase, and the codebase distinguishes two concepts:
+
+- **Piloted Ship** — `location == Sector`; has a `StellarObject` + `MovementState`; the only kind of ship the sector simulation (movement ticks, dead-reckoning, sector subscriptions, minimap, range checks) can see.
+- **Docked Ship** — `location == Station` (or `Ship` for carrier docking); no `StellarObject`; reachable only through the `Ship` table by player/station id.
+
+`get_player_ship` (client, `stdb/utils.rs`) returns the **Piloted** ship only — `None` while docked. This is correct behavior, not a bug, but the name does not say so; issue #149 (welcome-back panel suppressed for docked players) came from exactly this misreading.
+
+## Why this shape
+
+The rejected alternative was keeping the `StellarObject` alive with a `docked` flag. That would make "where is my ship" a single uniform query, but every movement tick, sector scan, collision/range check, and dead-reckoning extrapolation would need a docked-filter — and a forgotten filter means parked ships drifting through dock walls. Deleting the sobj makes the docked state *structurally* invisible to the simulation: the cheap, default-safe failure mode is "docked ships are absent," not "docked ships are erroneously simulated."
+
+## Consequences
+
+- Client UI must decide per-surface whether it cares about the **Piloted** ship (HUD, minimap, movement) or **any owned** ship (assets, welcome-back panel, out-of-play screen). Gating a should-always-show surface on the Piloted ship is the #149 failure mode — new UI should default to ownership checks (`ship table by player_id`) unless it genuinely needs a position.
+- `Ship.sobj_id == 0` is a sentinel, not a foreign key, while docked. Code must not resolve it.
+- Undock re-mints the sobj, so sobj ids are **not stable across dock cycles**; nothing may persist a sobj id as a long-lived ship reference — `ShipId` is the durable identity.
+- Canonical vocabulary (Piloted Ship / Docked Ship) lives in `CONTEXT.md` §3; `get_player_ship` should eventually be renamed `get_piloted_ship` to make the contract self-evident.


### PR DESCRIPTION
Documentation follow-up to #149, so the `get_player_ship` piloted-vs-owned confusion can't recur unexamined.

- **`docs/adr/0002-docking-removes-ship-from-sector-simulation.md`** — records the load-bearing decision: `dock_to_station` deletes the ship's `StellarObject` (`sobj_id` becomes a `0` sentinel), making docked ships structurally invisible to the simulation. Captures the rejected alternative (live sobj + docked flag) and the consequences: per-surface piloted-vs-owned UI gating, sobj ids unstable across dock cycles, eventual `get_player_ship` → `get_piloted_ship` rename.
- **`CONTEXT.md` §3** — canonical **Piloted Ship** / **Docked Ship** terms under the Ship entry, with "the player's ship" flagged as a banned-ambiguous phrase and the rule that always-show UI gates on ownership, not on a Piloted Ship existing.

No code changes. The `get_piloted_ship` rename is deliberately left for the #149 fix (or its own pass) — it touches 13 call sites and shouldn't ride a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)