### PR TITLE
Upgrade SpacetimeDB 2.3.0 → 2.5.0

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12.15", features = [
     "blocking",
     "rustls-tls",
 ], default-features = false }
-spacetimedb-sdk = "2.3.0"
+spacetimedb-sdk = "2.5.0"
 url = "2.5.4"
 solarance-shared = { path = "../solarance-shared" }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Karl Nyborg"]
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { version = "2.3.0" }
+spacetimedb = { version = "2.5.0" }
 spacetimedsl = "0.20.1"
 log = "0.4"
 glam = "0.30.2"


### PR DESCRIPTION
Brings the server module and client SDK from 2.3.0 to 2.5.0 (through 2.4.0 / 2.4.1). The CLI/local server were already on 2.5.0.

## Gotcha review (none blocking)

- **Zero documented breaking changes** in all three releases.
- **Views**: 2.5.0 notes say views/RLS "remain gated behind unstable" — verified empirically that our `#[spacetimedb::view]` messaging system compiles and publishes on 2.5 with no feature flag, same as 2.3.
- **spacetimedsl 0.20.1** requires `spacetimedb ^2.0.2`, so 2.5 satisfies it with no DSL bump available or needed.

## Verification

- [x] `task server:build` clean
- [x] `task server:publish-clear` against local 2.5.0 server — init seeded clean ("Database initialized", all faction timers created)
- [x] `spacetime generate` bindings regenerated
- [x] Client `cargo build` clean

## Notable upstream changes we benefit from silently

- 2.4.0 commitlog durability fix (trailing-bytes segment corruption on restart) — directly relevant to our M2 persistence guarantees.
- 2.4.1 primary-key support for procedural views → subscribed clients can get update events on view rows.
- 2.4.0 reducers now run on a dedicated synchronous WASM runtime (hot-path overhead removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)