### PR TITLE
Map: jumpgate edges, always-on labels, auto-fit + pan (#120)

### DIFF
--- a/client/src/gameplay/gui/map_window.rs
+++ b/client/src/gameplay/gui/map_window.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use egui::*;
 use macroquad::prelude::*;
 use spacetimedb_sdk::Table;
@@ -5,28 +7,64 @@ use spacetimedb_sdk::*;
 
 use crate::{server::bindings::*, stdb::utils::*};
 
+/// Shrink factor applied to the auto-fit scale so sectors don't touch the
+/// canvas edges. Developer-tunable — smaller = more padding around the network.
+const MAP_FIT_FACTOR: f32 = 0.82;
+/// Half-size (px) of a sector marker on the galaxy map.
+const MAP_SECTOR_RADIUS: f32 = 8.0;
+
 #[derive(PartialEq)]
-enum CurrentTab {
-    Ship,
-    Cargo,
+enum MapTab {
+    /// The current star system: its sectors + orbital objects (the implemented map).
+    System,
+    /// Galaxy-wide star-system overview — placeholder until post-MVP (#160).
+    Galaxy,
 }
 
 pub struct State {
-    current_tab: CurrentTab,
+    current_tab: MapTab,
 
     stroke: Stroke,
+
+    /// Accumulated pan offset (screen px) from dragging the galaxy map canvas.
+    /// Reset by the "Recenter" button. Zoom is intentionally not supported (#120).
+    pan: egui::Vec2,
 }
 
 impl State {
     pub fn new() -> Self {
         State {
-            current_tab: CurrentTab::Ship,
+            current_tab: MapTab::System,
 
             stroke: Stroke::new(2.0, Color32::from_rgb(25, 200, 100)),
+
+            pan: egui::Vec2::ZERO,
         }
     }
 
-    fn draw_galaxy_map(&self, ui: &mut egui::Ui, ctx: &DbConnection) {
+    /// Tab bar + dispatch. The dialog hosts a "System Map" (the current star
+    /// system) and a "Galaxy Map" (post-MVP placeholder, #160).
+    fn draw_galaxy_map(&mut self, ui: &mut egui::Ui, ctx: &DbConnection) {
+        ui.horizontal(|ui| {
+            ui.selectable_value(&mut self.current_tab, MapTab::System, "System Map");
+            ui.selectable_value(&mut self.current_tab, MapTab::Galaxy, "Galaxy Map");
+        });
+        ui.separator();
+
+        match self.current_tab {
+            MapTab::System => self.draw_system_map(ui, ctx),
+            MapTab::Galaxy => {
+                ui.vertical_centered(|ui| {
+                    ui.add_space(40.0);
+                    ui.weak("Galaxy-wide star-system overview — coming after MVP (#160).");
+                });
+            }
+        }
+    }
+
+    /// The current star system: sector dots, jumpgate edges, faded orbital
+    /// backdrop, with pan + auto-fit.
+    fn draw_system_map(&mut self, ui: &mut egui::Ui, ctx: &DbConnection) {
         let current_sector = if let Some(player_obj) = get_player_ship(ctx) {
             if let Some(sector) = ctx.db().sector().id().find(&player_obj.sector_id) {
                 sector
@@ -36,142 +74,167 @@ impl State {
         } else {
             return;
         };
+        let system_name = ctx
+            .db()
+            .star_system()
+            .id()
+            .find(&current_sector.system_id)
+            .map(|s| s.name)
+            .unwrap_or_else(|| format!("#{}", current_sector.system_id));
         ui.horizontal(|ui| {
-            ui.label("Current Sector:");
-            ui.label(&current_sector.name);
+            ui.label("System:");
+            ui.strong(&system_name);
+            ui.separator();
+            ui.label("Sector:");
+            ui.strong(&current_sector.name);
+            ui.separator();
+            if ui.button("Recenter").clicked() {
+                self.pan = egui::Vec2::ZERO;
+            }
+            ui.weak("drag to pan");
         });
 
         ui.separator();
 
-        // TODO Canvas of the galaxy
         Frame::canvas(ui.style()).show(ui, |ui| {
             let (response, painter) = ui.allocate_painter(
                 egui::Vec2::new(ui.available_width(), ui.available_height()),
-                Sense::hover(),
+                Sense::click_and_drag(),
             );
 
-            let to_screen = emath::RectTransform::from_to(
-                egui::Rect::from_min_size(Pos2::ZERO, response.rect.size()),
-                response.rect,
-            );
+            // Pan the whole map by dragging anywhere on the canvas.
+            self.pan += response.drag_delta();
 
-            let mut shapes = Vec::new();
-            let offset = pos2(response.rect.width() / 2., response.rect.height() / 2.);
-            let zoom_px = 1.0;
-            let sector_radius = 8.0;
+            // Collect sectors once; bail if the world hasn't loaded yet.
+            let sectors: Vec<Sector> = ctx.db().sector().iter().collect();
+            if sectors.is_empty() {
+                return;
+            }
 
-            for (_i, object) in ctx.db().star_system_object().iter().enumerate() {
+            // Auto-fit: derive a uniform world→screen scale from the sector
+            // bounding box so the whole network fits the available canvas at
+            // any window size. Resizing re-fits automatically (dest = rect).
+            let mut min_w = glam::Vec2::splat(f32::INFINITY);
+            let mut max_w = glam::Vec2::splat(f32::NEG_INFINITY);
+            for s in &sectors {
+                min_w = min_w.min(glam::vec2(s.x, s.y));
+                max_w = max_w.max(glam::vec2(s.x, s.y));
+            }
+            let span = (max_w - min_w).max(glam::Vec2::splat(1.0));
+            let center_world = (min_w + max_w) * 0.5;
+            let avail = response.rect.size();
+            let scale = (avail.x / span.x).min(avail.y / span.y) * MAP_FIT_FACTOR;
+            let screen_center = response.rect.center();
+            let pan = self.pan;
+
+            // Uniform world→screen mapping (keeps proportions; non-distorting).
+            let to_screen = |wx: f32, wy: f32| -> Pos2 {
+                pos2(
+                    screen_center.x + (wx - center_world.x) * scale + pan.x,
+                    screen_center.y + (wy - center_world.y) * scale + pan.y,
+                )
+            };
+
+            let mut backdrop = Vec::new();
+            let mut edges = Vec::new();
+            let mut markers = Vec::new();
+
+            // --- Orbital backdrop (faded), current system only ---------------
+            // Kept behind the sector network; opacity is reduced so the dots
+            // and jumpgate edges stay the primary visual layer.
+            for object in ctx.db().star_system_object().iter() {
                 if object.system_id != current_sector.system_id {
                     continue;
                 }
-
                 let stroke = match object.kind {
-                    StarSystemObjectKind::Star => Stroke {
-                        width: 3.,
-                        color: Color32::YELLOW,
-                    },
-                    StarSystemObjectKind::Planet => Stroke {
-                        width: 1.,
-                        color: Color32::LIGHT_BLUE,
-                    },
-                    StarSystemObjectKind::Moon => Stroke {
-                        width: 1.,
-                        color: Color32::GRAY,
-                    },
-                    StarSystemObjectKind::AsteroidBelt => Stroke {
-                        width: object.rotation_or_width_km,
-                        color: Color32::from_rgba_unmultiplied(115, 52, 32, 16),
-                    },
-                    StarSystemObjectKind::NebulaBelt => Stroke {
-                        width: object.rotation_or_width_km,
-                        color: Color32::from_rgba_unmultiplied(181, 69, 255, 16),
-                    },
+                    StarSystemObjectKind::Star => {
+                        Stroke::new(2.0, Color32::from_rgba_unmultiplied(255, 255, 0, 70))
+                    }
+                    StarSystemObjectKind::Planet => {
+                        Stroke::new(1.0, Color32::from_rgba_unmultiplied(173, 216, 230, 70))
+                    }
+                    StarSystemObjectKind::Moon => {
+                        Stroke::new(1.0, Color32::from_rgba_unmultiplied(128, 128, 128, 70))
+                    }
+                    StarSystemObjectKind::AsteroidBelt => Stroke::new(
+                        object.rotation_or_width_km,
+                        Color32::from_rgba_unmultiplied(115, 52, 32, 16),
+                    ),
+                    StarSystemObjectKind::NebulaBelt => Stroke::new(
+                        object.rotation_or_width_km,
+                        Color32::from_rgba_unmultiplied(181, 69, 255, 16),
+                    ),
                 };
 
                 match object.kind {
                     StarSystemObjectKind::Star
                     | StarSystemObjectKind::Planet
                     | StarSystemObjectKind::Moon => {
-                        let point_in_system =
+                        let p =
                             glam::Vec2::from_angle(object.rotation_or_width_km) * object.orbit_au;
-
-                        let mut point = pos2(
-                            point_in_system.x * zoom_px + offset.x,
-                            point_in_system.y * zoom_px + offset.y,
-                        );
-                        point = to_screen.from().clamp(point);
-                        let point_in_screen = to_screen.transform_pos(point);
-
                         let radius = match object.kind {
-                            StarSystemObjectKind::Star => sector_radius * 1.5,
-                            StarSystemObjectKind::Planet => sector_radius * 0.85,
-                            StarSystemObjectKind::Moon => sector_radius * 0.5,
+                            StarSystemObjectKind::Star => MAP_SECTOR_RADIUS * 1.5,
+                            StarSystemObjectKind::Planet => MAP_SECTOR_RADIUS * 0.85,
+                            StarSystemObjectKind::Moon => MAP_SECTOR_RADIUS * 0.5,
                             _ => unreachable!(),
                         };
-
-                        shapes.push(Shape::circle_stroke(point_in_screen, radius, stroke));
+                        backdrop.push(Shape::circle_stroke(to_screen(p.x, p.y), radius, stroke));
                     }
                     StarSystemObjectKind::AsteroidBelt | StarSystemObjectKind::NebulaBelt => {
-                        let mut point = pos2(zoom_px + offset.x, zoom_px + offset.y);
-                        point = to_screen.from().clamp(point);
-                        let point_in_screen = to_screen.transform_pos(point);
-
-                        shapes.push(Shape::circle_stroke(
-                            point_in_screen,
-                            object.orbit_au,
+                        // Belts are rings centered on the system origin.
+                        backdrop.push(Shape::circle_stroke(
+                            to_screen(0.0, 0.0),
+                            object.orbit_au * scale,
                             stroke,
                         ));
                     }
                 }
             }
 
-            for (i, sector) in ctx.db().sector().iter().enumerate() {
-                let size = egui::Vec2::splat(2.0 * sector_radius);
-
-                let mut point = pos2(sector.x * zoom_px + offset.x, sector.y * zoom_px + offset.y);
-                let point_in_screen = to_screen.transform_pos(point);
-
-                let point_rect = egui::Rect::from_center_size(point_in_screen, size);
-                let point_id = response.id.with(i);
-                let point_response = ui.interact(point_rect, point_id, Sense::click());
-
-                point += point_response.drag_delta();
-                point = to_screen.from().clamp(point);
-
-                let point_in_screen = to_screen.transform_pos(point);
-                let stroke = if current_sector.id == sector.id {
-                    self.stroke
-                } else {
-                    ui.style().interact(&point_response).fg_stroke
-                };
-
-                if point_response.hovered() {
-                    painter.text(
-                        to_screen.transform_pos(point),
-                        Align2::CENTER_BOTTOM,
-                        format!("{}", sector.name),
-                        FontId::monospace(16.0),
-                        Color32::WHITE,
-                    );
-                    painter.text(
-                        to_screen.transform_pos(point),
-                        Align2::CENTER_TOP,
-                        format!("({},{})", sector.x, sector.y),
-                        FontId::monospace(8.0),
-                        Color32::WHITE,
-                    );
+            // --- Jumpgate edges ---------------------------------------------
+            // One line per connected sector pair. Gates are bidirectional
+            // (`connect_sectors_with_warpgates` makes two rows), so dedup on the
+            // unordered (a, b) key to avoid stacking two edges per pair.
+            let positions: HashMap<u64, (f32, f32)> =
+                sectors.iter().map(|s| (s.id, (s.x, s.y))).collect();
+            let edge_stroke = Stroke::new(1.5, Color32::from_rgb(90, 160, 150));
+            let mut seen: HashSet<(u64, u64)> = HashSet::new();
+            for gate in ctx.db().jump_gate().iter() {
+                let (a, b) = (gate.current_sector_id, gate.target_sector_id);
+                let key = if a <= b { (a, b) } else { (b, a) };
+                if !seen.insert(key) {
+                    continue;
                 }
+                if let (Some(&(ax, ay)), Some(&(bx, by))) =
+                    (positions.get(&a), positions.get(&b))
+                {
+                    edges.push(Shape::line_segment(
+                        [to_screen(ax, ay), to_screen(bx, by)],
+                        edge_stroke,
+                    ));
+                }
+            }
 
-                let min = Pos2::new(
-                    point_in_screen.x - sector_radius,
-                    point_in_screen.y - sector_radius,
+            // --- Sector markers ---------------------------------------------
+            // Build the dot shapes now; labels are drawn last so they sit on
+            // top of every other layer.
+            let hover = response.hover_pos();
+            let mut sector_screens: Vec<(&Sector, Pos2)> = Vec::with_capacity(sectors.len());
+            for sector in &sectors {
+                let center = to_screen(sector.x, sector.y);
+                sector_screens.push((sector, center));
+
+                let stroke = if current_sector.id == sector.id {
+                    self.stroke // preserved green highlight for the current sector
+                } else {
+                    Stroke::new(1.5, Color32::from_gray(180))
+                };
+                let rect = egui::Rect::from_center_size(
+                    center,
+                    egui::Vec2::splat(2.0 * MAP_SECTOR_RADIUS),
                 );
-                let max = Pos2::new(
-                    point_in_screen.x + sector_radius,
-                    point_in_screen.y + sector_radius,
-                );
-                shapes.push(Shape::rect_stroke(
-                    egui::Rect { min, max },
+                markers.push(Shape::rect_stroke(
+                    rect,
                     CornerRadius {
                         nw: 0,
                         ne: 4,
@@ -182,17 +245,34 @@ impl State {
                     StrokeKind::Middle,
                 ));
             }
-            painter.extend(shapes);
-        });
 
-        // egui::Frame::group(ui.style())
-        //   .inner_margin(0.0)
-        //   .show(ui, |ui| {
-        //     //
-        //     let mut reset_view = false;
-        //     let mut inner_rect = egui::Rect::NAN;
-        //     egui::
-        //   });
+            // Paint in z-order: backdrop, edges, sector dots.
+            painter.extend(backdrop);
+            painter.extend(edges);
+            painter.extend(markers);
+
+            // Labels on top. Names are always-on; coordinates appear on hover.
+            for (sector, center) in &sector_screens {
+                painter.text(
+                    pos2(center.x, center.y - MAP_SECTOR_RADIUS - 2.0),
+                    Align2::CENTER_BOTTOM,
+                    &sector.name,
+                    FontId::monospace(8.0),
+                    Color32::WHITE,
+                );
+                if let Some(h) = hover {
+                    if (h - *center).length() <= MAP_SECTOR_RADIUS + 4.0 {
+                        painter.text(
+                            pos2(center.x, center.y + MAP_SECTOR_RADIUS + 2.0),
+                            Align2::CENTER_TOP,
+                            format!("({:.0}, {:.0})", sector.x, sector.y),
+                            FontId::monospace(7.0),
+                            Color32::LIGHT_GRAY,
+                        );
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -202,7 +282,7 @@ pub fn draw(
     state: &mut State,
     open: &mut bool,
 ) -> Option<egui::InnerResponse<Option<()>>> {
-    egui::Window::new("Galatic Maps")
+    egui::Window::new("Galactic Map")
         .open(open)
         .title_bar(true)
         .resizable(true)

--- a/client/src/stdb/connector/subscriptions.rs
+++ b/client/src/stdb/connector/subscriptions.rs
@@ -47,13 +47,11 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
         WHERE s.player_id = '{}'",
         ctx.identity()
     );
-    let jump_gate = format!(
-        "SELECT j.*
-        FROM ship s
-        JOIN jump_gate j ON s.sector_id = j.current_sector_id
-        WHERE s.player_id = '{}'",
-        ctx.identity()
-    );
+    // Galaxy map (#120) needs the whole jumpgate network, not just gates in the
+    // player's current sector. Gate positions are static public map data, so a
+    // full-table subscription is fine (the galaxy has only a handful of gates).
+    // This is a superset of the old current-sector filter, so in-sector gate
+    // rendering / `use_jumpgate` still work.
     let ship = format!(
         "SELECT * from ship" // "SELECT o.*
                              // FROM ship o
@@ -110,7 +108,7 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
             "SELECT * FROM faction_standing",
             "SELECT * FROM item_definition",
             cargo_crate.as_str(),
-            jump_gate.as_str(),
+            "SELECT * FROM jump_gate",
             "SELECT * FROM player",
             player_ship_controller.as_str(),
             "SELECT * FROM star_system",


### PR DESCRIPTION
Closes #120 (Ticket A of the 2-ticket map split).

Reworks the player's **Galactic Map** so a player can glance at it and understand the sector network. Verified visually by the maintainer.

## Map (`client/src/gameplay/gui/map_window.rs`)
- **Jumpgate edges** — one line per connected sector pair from `jump_gate` rows, deduped on the unordered `(a,b)` key so bidirectional gates don't stack two edges.
- **Always-on labels** — sector names visible at all times (font 8); coordinates shown on hover.
- **Auto-fit + pan, no zoom** — a uniform world→screen scale is computed each frame from the sector bounding box, so the whole network fits and re-fits on window resize. Drag anywhere to pan; **Recenter** button resets it. `MAP_FIT_FACTOR` is developer-tunable.
- **Faded orbital backdrop** — sun/planets/moons/belts kept but rendered faded behind the sector network so dots + edges stay primary.
- **Current sector** keeps its green highlight.
- **System / Galaxy tabs** — the dialog now has a default **System Map** (the implemented view: the current star system's sectors + orbital objects) and a **Galaxy Map** placeholder (post-MVP, #160). Header shows the current system and sector names. Repurposing the dead `CurrentTab` enum into `MapTab` also cleared two stale dead-code warnings.
- **Title typo fixed** — "Galatic Maps" → "Galactic Map".

## Supporting change (`client/src/stdb/connector/subscriptions.rs`)
The client subscribed to jump gates only in the player's current sector, so the map couldn't see the network. Broadened to `SELECT * FROM jump_gate` — static public map data, only a handful of rows, and a superset of the old filter so in-sector gate rendering / `use_jumpgate` are unaffected.

## Out of scope (Ticket B / follow-ups)
- Click → sector details, construction overlays, faction tint, zoom, route planning (deferred to M5 Ticket B per the issue).
- Populating the Galaxy Map tab — filed as **#160**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)