### PR TITLE
fix(render): kill cross-sector jumpgate render flicker (#89)

### DIFF
--- a/client/src/gameplay/render.rs
+++ b/client/src/gameplay/render.rs
@@ -28,11 +28,33 @@ pub fn sector(game_state: &mut GameState) {
     let db = &game_state.ctx.db;
     let now_micros = now_unix_micros();
 
+    // (#89) The player's current sector is wherever their in-sector ship is.
+    // Used below to drop any stellar object whose `sector_id` doesn't match —
+    // see the wrong-sector filter in the first pass. `None` while docked /
+    // out-of-play, in which case we don't filter (nothing to anchor to).
+    let player_sector = player_ship.as_ref().map(|s| s.sector_id);
+
     // Collect ships to draw after stations
     let mut ships_to_draw: Vec<(Ship, RenderPose, ShipTypeDefinition)> = Vec::new();
 
     // First pass: Draw everything except ships
     for object in db.stellar_object().iter() {
+        // (#89) Wrong-sector render filter (approach (b)). `try_to_use_jumpgate`
+        // flips Ship/ShipStatus/StellarObject.sector_id + the movement snapshot
+        // in one server transaction, but the rows can briefly land out of order
+        // on the client — and pre-#84 the cache holds other sectors' objects
+        // outright. Skipping any object not in the player's sector kills the
+        // cross-sector ghost/flicker for every kind, and during the transient
+        // it hides the player's own ship for at most a frame rather than drawing
+        // it at a stale position. Cosmetic only: server state is consistent.
+        // ponytail: StellarObject.sector_id is atomic with the row's pose, so
+        // this subsumes approach (a) — there is no client-side prediction
+        // buffer to separately invalidate.
+        if let Some(ps) = player_sector {
+            if object.sector_id != ps {
+                continue;
+            }
+        }
         // Build a render pose for this object — predicts forward for ships
         // and cargo crates, reads the static position column for asteroids /
         // stations / jumpgates.


### PR DESCRIPTION
Closes #89.

## What

Adds a wrong-sector render filter (approach **(b)** from #89) to `client/src/gameplay/render.rs` `sector()`. The first render pass now skips any `StellarObject` whose `sector_id` ≠ the player's current sector, so other-sector rows in the client cache can no longer ghost/flicker into view during jumpgate transit.

- Filters at the `StellarObject` level, so it covers **all** kinds — ships, stations, asteroids, gates, crates, and radar blips — not just ships.
- During any transient row-order skew it hides the player's own ship for at most one frame rather than drawing it at a stale position.
- No-op while docked / out-of-play (no anchor sector → no filtering).

## Why approach (a) was omitted

(a) ("sector-change invalidates prediction / snap to latest snapshot") assumes a client-side prediction buffer to invalidate — there isn't one. The renderer reads `ship.movement` fresh each frame, `transit_ship_to_sector` writes a clean-stop snapshot **atomically with `sector_id` on the same `Ship` row**, and `predict_movement` returns the arrival pose for any `dt`. So (b) fully subsumes (a) here. Documented inline with a `ponytail:` comment. Revisit if a prediction/interpolation buffer ever lands (see #85 / #84 — cross-linked there).

## Scope

Cosmetic only — server state is already consistent. Approach (c) (warp effect / hide-during-transit) deferred to #169 per maintainer.

## Test

`cargo check` on the client crate is clean (pre-existing dead-code warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)