### PR TITLE
chore(deps): bump SpacetimeDB to 2.6.0 across all rust crates

### DIFF
--- a/client-admin/Cargo.toml
+++ b/client-admin/Cargo.toml
@@ -23,4 +23,4 @@ path = "src/main.rs"
 egui = "0.31.1"
 egui-macroquad = "0.17.3"
 macroquad = { version = "0.4.14", features = ["backtrace"] }
-spacetimedb-sdk = "2.5.0"
+spacetimedb-sdk = "2.6.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12.15", features = [
     "blocking",
     "rustls-tls",
 ], default-features = false }
-spacetimedb-sdk = "2.5.0"
+spacetimedb-sdk = "2.6.0"
 url = "2.5.4"
 solarance-shared = { path = "../solarance-shared" }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Karl Nyborg"]
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { version = "2.5.0" }
+spacetimedb = { version = "2.6.0" }
 spacetimedsl = "0.20.1"
 log = "0.4"
 glam = "0.30.2"

--- a/solarance-shared/Cargo.toml
+++ b/solarance-shared/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-spacetimedb = "2.3.0"
+spacetimedb = "2.6.0"
 glam = "0.30.2"


### PR DESCRIPTION
Aligns all Rust crates' SpacetimeDB dependency with the locally-installed **2.6.0** binary.

| Crate | Dependency | → |
|---|---|---|
| `server` (module) | `spacetimedb` | 2.5.0 → 2.6.0 |
| `solarance-shared` | `spacetimedb` | 2.3.0 → 2.6.0 |
| `client` | `spacetimedb-sdk` | 2.5.0 → 2.6.0 |
| `client-admin` | `spacetimedb-sdk` | 2.5.0 → 2.6.0 |

## Notes
- [2.6.0](https://github.com/clockworklabs/SpacetimeDB/releases/tag/v2.6.0) is additive — view primary keys + commitlog config knobs. **No breaking Rust API changes**, so no code migration and no binding regeneration.
- Lockfiles already resolved to 2.6.0 via the existing caret ranges, so only the declared `Cargo.toml` versions change.
- `cargo check` clean on all four crates against 2.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)