### PR TITLE
feat(mining): per-sector asteroid ore composition (#164)

### DIFF
--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -9,7 +9,10 @@ use crate::{
         factions::{
             FACTION_FACTIONLESS, FACTION_INDEPENDENT_WORLDS_ALLIANCE, FACTION_LRAK_COMBINE, FACTION_REDIAR_FEDERATION
         },
-        item_types::{ITEM_CARBON_ORE, ITEM_GOLD_ORE, ITEM_IRON_ORE, ITEM_SILICON_ORE},
+        item_types::{
+            ITEM_CARBON_ORE, ITEM_GOLD_ORE, ITEM_ICE_ORE, ITEM_IRON_ORE, ITEM_SILICON_ORE,
+            ITEM_URANIUM_ORE, ITEM_VIVEIUM_ORE,
+        },
     },
     logic::{sectors::asteroid_fields::fill_asteroid_sector, stations::{contribution::create_construction_site, *}, stellarobjects::stellar_object_creation::create_sobj},
     tables::{
@@ -232,20 +235,31 @@ fn setup_sector_connections(
     Ok(())
 }
 
-/// Stocks the mining sectors with asteroid fields. Yield "type" is approximated
-/// via density (`sparseness`) and rare-ore skew (`rarity`) — the spawn roll
-/// distribution is global, so per-sector ore *composition* (e.g. "water +
-/// viveium") isn't expressible yet; tracked as a follow-up to the asteroid
-/// spawn logic.
+/// Stocks the mining sectors with asteroid fields. Each field can declare an
+/// explicit per-sector ore composition (`ore_weights`); sectors left with an
+/// empty composition fall back to the global rarity-skewed distribution, so
+/// `sparseness`/`rarity` still drive density and rare-ore skew there.
 fn populate_sectors_with_asteroids(
     dsl: &DSL<'_, ReducerContext>,
     s: &ProcyonSectors,
 ) -> Result<(), String> {
+    // Relative ore weights within a sector — values need not sum to 100.
+    let ore = |pairs: &[(u32, u16)]| -> Vec<OreWeight> {
+        pairs
+            .iter()
+            .map(|(item_id, weight)| OreWeight {
+                item_id: *item_id,
+                weight: *weight,
+            })
+            .collect()
+    };
+
     let field = |sector: &Sector,
                  sparseness: u8,
                  rarity: u8,
                  cluster_extent: f32,
-                 cluster_inner: Option<f32>|
+                 cluster_inner: Option<f32>,
+                 ore_weights: Vec<OreWeight>|
      -> Result<(), String> {
         let created = dsl.create_asteroid_sector(CreateAsteroidSector {
             id: sector.get_id(),
@@ -253,15 +267,63 @@ fn populate_sectors_with_asteroids(
             rarity,
             cluster_extent,
             cluster_inner,
+            ore_weights,
         })?;
         fill_asteroid_sector(dsl, &created)
     };
 
-    field(&s.tarols_belt, 2, 25, 3000.0, Some(1000.0))?; // moderate, mixed
-    field(&s.ore_trench, 5, 50, 5000.0, None)?; // dense, rare-ore rich
-    field(&s.quiet_belt, 6, 70, 5000.0, None)?; // high yield
-    field(&s.iron_furrow, 4, 10, 4000.0, None)?; // iron-heavy, common
-    field(&s.karrens_reach, 3, 40, 3500.0, Some(800.0))?; // medium
+    // Empty composition → global default distribution (rarity-skewed).
+    field(&s.tarols_belt, 2, 25, 3000.0, Some(1000.0), vec![])?; // moderate, mixed (default mix)
+    field(
+        &s.ore_trench,
+        5,
+        50,
+        5000.0,
+        None,
+        ore(&[
+            (ITEM_URANIUM_ORE, 30),
+            (ITEM_VIVEIUM_ORE, 25),
+            (ITEM_GOLD_ORE, 20),
+            (ITEM_IRON_ORE, 25),
+        ]),
+    )?; // dense, rare-ore rich
+    field(
+        &s.quiet_belt,
+        6,
+        70,
+        5000.0,
+        None,
+        ore(&[
+            (ITEM_GOLD_ORE, 30),
+            (ITEM_SILICON_ORE, 30),
+            (ITEM_VIVEIUM_ORE, 20),
+            (ITEM_ICE_ORE, 20),
+        ]),
+    )?; // high yield
+    field(
+        &s.iron_furrow,
+        4,
+        10,
+        4000.0,
+        None,
+        ore(&[
+            (ITEM_IRON_ORE, 70),
+            (ITEM_SILICON_ORE, 20),
+            (ITEM_GOLD_ORE, 10),
+        ]),
+    )?; // iron-heavy, common
+    field(
+        &s.karrens_reach,
+        3,
+        40,
+        3500.0,
+        Some(800.0),
+        ore(&[
+            (ITEM_CARBON_ORE, 50),
+            (ITEM_ICE_ORE, 30),
+            (ITEM_IRON_ORE, 20),
+        ]),
+    )?; // carbon-bearing
 
     Ok(())
 }

--- a/server/src/logic/sectors/asteroid_fields.rs
+++ b/server/src/logic/sectors/asteroid_fields.rs
@@ -17,9 +17,59 @@ fn target_population(asteroid_sector: &AsteroidSector) -> usize {
     (asteroid_sector.get_sparseness() * 10).into()
 }
 
+/// Picks an ore `item_id` from `weights` given `roll` in `0..sum(weights)`.
+/// Returns `None` when `weights` is empty or every weight is zero, signalling
+/// the caller to fall back to the global distribution. Pure (no RNG) so it can
+/// be unit-tested directly.
+fn pick_weighted_ore(weights: &[OreWeight], roll: u32) -> Option<u32> {
+    let mut remaining = roll;
+    for w in weights {
+        let weight = w.weight as u32;
+        if weight == 0 {
+            continue;
+        }
+        if remaining < weight {
+            return Some(w.item_id);
+        }
+        remaining -= weight;
+    }
+    None
+}
+
+/// Rolls the ore type for a new asteroid. Uses the sector's explicit
+/// `ore_weights` composition when set; otherwise falls back to the global
+/// rarity-skewed distribution (the historical behaviour).
+fn roll_ore_item(dsl: &DSL<'_, ReducerContext>, asteroid_sector: &AsteroidSector) -> u32 {
+    let weights = asteroid_sector.get_ore_weights();
+    let total: u32 = weights.iter().map(|w| w.weight as u32).sum();
+    if total > 0 {
+        let roll = dsl.ctx().rng().gen_range(0..total);
+        if let Some(item_id) = pick_weighted_ore(weights, roll) {
+            return item_id;
+        }
+    }
+
+    // Fallback: global rarity-skewed distribution. Only ONE of the two rolls is
+    // skewed by rarity, so lower rarities always retain a chance.
+    let a = dsl.ctx().rng().gen_range(0..100);
+    let b = dsl
+        .ctx()
+        .rng()
+        .gen_range((*asteroid_sector.get_rarity() as i32)..100);
+    match a.min(b) {
+        0..25 => ITEM_ICE_ORE,
+        25..60 => ITEM_IRON_ORE,
+        60..75 => ITEM_SILICON_ORE,
+        75..85 => ITEM_GOLD_ORE,
+        85..90 => ITEM_VIVEIUM_ORE,
+        _ => ITEM_URANIUM_ORE,
+    }
+}
+
 /// Spawns a single asteroid at a random position inside the field, with ore
-/// type skewed by the sector's rarity. Pure spawn logic — authorization is the
-/// calling reducer's responsibility. Returns `None` if the creation failed.
+/// type drawn from the sector's composition (or the global fallback). Pure spawn
+/// logic — authorization is the calling reducer's responsibility. Returns `None`
+/// if the creation failed.
 fn spawn_random_asteroid_in_field(
     dsl: &DSL<'_, ReducerContext>,
     asteroid_sector: &AsteroidSector,
@@ -31,27 +81,7 @@ fn spawn_random_asteroid_in_field(
     };
     let pos = Vec2::from_glam(glam::Vec2::from_angle(dsl.ctx().rng().gen_range(0.0..2.0 * PI)) * dist);
 
-    let roll_with_disadvantage = {
-        let a = dsl.ctx().rng().gen_range(0..100);
-        // Only ONE of the 'rolls' should be effected by rarity, so that there's always a chance for lower rarities.
-        let b = dsl.ctx()
-            .rng()
-            .gen_range((*asteroid_sector.get_rarity() as i32)..100);
-        if a < b {
-            a
-        } else {
-            b
-        }
-    };
-
-    let item = ItemDefinitionId::new(match roll_with_disadvantage {
-        0..25 => ITEM_ICE_ORE,
-        25..60 => ITEM_IRON_ORE,
-        60..75 => ITEM_SILICON_ORE,
-        75..85 => ITEM_GOLD_ORE,
-        85..90 => ITEM_VIVEIUM_ORE,
-        _ => ITEM_URANIUM_ORE,
-    });
+    let item = ItemDefinitionId::new(roll_ore_item(dsl, asteroid_sector));
 
     let amount = dsl.ctx().rng().gen_range(500..2000);
 
@@ -88,6 +118,35 @@ pub fn fill_asteroid_sector(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_weighted_ore;
+    use crate::tables::sectors::OreWeight;
+
+    fn w(item_id: u32, weight: u16) -> OreWeight {
+        OreWeight { item_id, weight }
+    }
+
+    #[test]
+    fn weighted_pick_respects_boundaries() {
+        // total = 5; rolls 0,1,2 -> item 10; rolls 3,4 -> item 20.
+        let weights = vec![w(10, 3), w(20, 2)];
+        assert_eq!(pick_weighted_ore(&weights, 0), Some(10));
+        assert_eq!(pick_weighted_ore(&weights, 2), Some(10));
+        assert_eq!(pick_weighted_ore(&weights, 3), Some(20));
+        assert_eq!(pick_weighted_ore(&weights, 4), Some(20));
+    }
+
+    #[test]
+    fn empty_or_zero_weights_fall_through() {
+        assert_eq!(pick_weighted_ore(&[], 0), None);
+        // zero-weight entries are skipped, not selected.
+        let weights = vec![w(1, 0), w(2, 1)];
+        assert_eq!(pick_weighted_ore(&weights, 0), Some(2));
+        assert_eq!(pick_weighted_ore(&vec![w(1, 0)], 0), None);
+    }
 }
 
 /// Maintains asteroid populations in a sector. When a field has dropped below

--- a/server/src/tables/sectors.rs
+++ b/server/src/tables/sectors.rs
@@ -1,4 +1,4 @@
-use spacetimedb::table;
+use spacetimedb::{table, SpacetimeType};
 use spacetimedsl::*;
 
 use crate::{
@@ -66,6 +66,16 @@ pub struct Sector {
     background_gfx_key: Option<String>, // Key for client to look up background image
 }
 
+/// One entry in a sector's asteroid ore composition: the relative `weight`
+/// with which `item_id` (an ore `ItemDefinition` id) is rolled when spawning an
+/// asteroid. Weights are relative *within* a sector's `ore_weights` list — they
+/// need not sum to any particular total.
+#[derive(SpacetimeType, Debug, Clone, PartialEq)]
+pub struct OreWeight {
+    pub item_id: u32,
+    pub weight: u16,
+}
+
 #[dsl(plural_name = asteroid_sectors, method(update = false))]
 #[table(accessor = asteroid_sector)]
 pub struct AsteroidSector {
@@ -78,6 +88,10 @@ pub struct AsteroidSector {
     rarity: u8,                 // Skews the amount of spawned asteroids with high rarity ores
     cluster_extent: f32,        // How far from 0,0 can asteroids spawn
     cluster_inner: Option<f32>, // How far from 0,0 can asteroids NOT spawn
+    /// Per-sector ore composition. When non-empty the spawn roll picks an ore
+    /// weighted by this list (ignoring `rarity`); when empty it falls back to
+    /// the global rarity-skewed distribution. See `asteroid_fields::roll_ore_item`.
+    ore_weights: Vec<OreWeight>,
 }
 
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #164.

## What

Lets an asteroid sector declare **which ores it yields and in what proportion**, replacing the single hardcoded global distribution for sectors that opt in.

- **Schema** — `AsteroidSector` gains `ore_weights: Vec<OreWeight>` (`OreWeight { item_id: u32, weight: u16 }`, a `SpacetimeType` modeled on the existing `ResourceAmount`). Weights are relative within a sector — they need not sum to 100.
- **Spawn roll** (`asteroid_fields::roll_ore_item`) — when `ore_weights` is non-empty, pick an ore weighted by the list (composition supersedes `rarity`); when empty, fall back to the **existing** global rarity-skewed `match`, so untouched sectors behave exactly as before.
- **Seed** — Procyon mining sectors now carry real mixes:
  | Sector | Composition |
  |---|---|
  | Tarol's Belt | _(empty → default global mix)_ |
  | Ore Trench | uranium/viveium/gold/iron (rare-rich) |
  | Quiet Belt | gold/silicon/viveium/ice |
  | Iron Furrow | iron 70 / silicon 20 / gold 10 |
  | Karren's Reach | **carbon 50** / ice 30 / iron 20 |

## Acceptance criteria
- [x] Two sectors seed with different mixes and mine out differently (Iron Furrow vs Ore Trench).
- [x] Carbon ore can drop where specified (Karren's Reach) — it was previously unreachable in the global table.
- [x] Sectors with no explicit spec still spawn a reasonable default mix (Tarol's Belt → global fallback).

## Tests
- Unit tests for the pure weighted selection (`pick_weighted_ore`): boundary correctness + empty/zero-weight fall-through. `cargo test` green; `cargo check` clean.

## Deploy note
This adds a column to `AsteroidSector`, so the module needs a republish — and since it changes an existing table's schema, a `--clear-database` publish (standard for the dev seed) is the simplest path. Composition only takes effect on a fresh galaxy seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)