### PR TITLE
feat(admin): read-only galaxy overview (#145 increment 1)

### DIFF
--- a/client-admin/src/app.rs
+++ b/client-admin/src/app.rs
@@ -148,6 +148,9 @@ struct GalaxyData {
     sector_lines: Vec<String>,
     station_lines: Vec<String>,
     gate_lines: Vec<String>,
+    /// Read-only live-state snapshot (#145): players and ships (grouped by sector).
+    player_lines: Vec<String>,
+    ship_lines: Vec<String>,
 }
 
 pub struct AdminApp {
@@ -367,13 +370,73 @@ fn gather_galaxy(conn: &DbConnection) -> GalaxyData {
         .station()
         .iter()
         .map(|st| {
+            // Append a build-progress suffix while a matching construction site
+            // is still in progress (id is shared with the station).
+            let suffix = match db.station_under_construction().id().find(&st.id) {
+                Some(uc) if !uc.is_operational => {
+                    format!("  [building {:.0}%]", uc.construction_progress_percentage)
+                }
+                _ => String::new(),
+            };
             format!(
-                "#{} {:?} \"{}\"  sector {}  fac {}",
-                st.id, st.size, st.name, st.sector_id, st.owner_faction_id
+                "#{} {:?} \"{}\"  sector {}  fac {}{}",
+                st.id, st.size, st.name, st.sector_id, st.owner_faction_id, suffix
             )
         })
         .collect();
     station_lines.sort();
+
+    // Players: identity, username, faction, online status, credits, last login.
+    let faction_name = |fid: u32| {
+        factions
+            .iter()
+            .find(|(id, _)| *id == fid)
+            .map(|(_, n)| n.clone())
+            .unwrap_or_else(|| format!("fac {fid}"))
+    };
+    let mut player_lines: Vec<String> = db
+        .player()
+        .iter()
+        .map(|p| {
+            let status = if p.logged_in { "online" } else { "offline" };
+            let last = match p.last_login {
+                Some(t) => format!("  last {}", t.to_micros_since_unix_epoch()),
+                None => "  never logged in".to_string(),
+            };
+            format!(
+                "{}  [{}]  {}  {}  {}cr{}",
+                p.username,
+                p.id.to_abbreviated_hex(),
+                status,
+                faction_name(p.faction_id.value),
+                p.credits,
+                last,
+            )
+        })
+        .collect();
+    player_lines.sort();
+
+    // Ships, grouped by sector (sector_id then ship id).
+    let mut ships: Vec<(u64, u64, String)> = db
+        .ship()
+        .iter()
+        .map(|s| {
+            (
+                s.sector_id,
+                s.id,
+                format!(
+                    "sector {}  ship #{}  {:?}  type {}  owner {}",
+                    s.sector_id,
+                    s.id,
+                    s.location,
+                    s.shiptype_id,
+                    s.player_id.to_abbreviated_hex(),
+                ),
+            )
+        })
+        .collect();
+    ships.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    let ship_lines: Vec<String> = ships.into_iter().map(|(_, _, line)| line).collect();
 
     let mut gate_lines: Vec<String> = db
         .jump_gate()
@@ -391,6 +454,8 @@ fn gather_galaxy(conn: &DbConnection) -> GalaxyData {
         sector_lines,
         station_lines,
         gate_lines,
+        player_lines,
+        ship_lines,
     }
 }
 
@@ -529,14 +594,18 @@ fn connected_ui(
         .show(egui_ctx, |ui| {
             ui.heading("Current galaxy");
             ui.label(format!(
-                "{} systems · {} sectors · {} stations · {} gates",
+                "{} systems · {} sectors · {} stations · {} gates · {} players · {} ships",
                 galaxy.systems.len(),
                 galaxy.sectors.len(),
                 galaxy.station_lines.len(),
                 galaxy.gate_lines.len(),
+                galaxy.player_lines.len(),
+                galaxy.ship_lines.len(),
             ));
             ui.separator();
             egui::ScrollArea::vertical().show(ui, |ui| {
+                section_list(ui, "Players", &galaxy.player_lines);
+                section_list(ui, "Ships", &galaxy.ship_lines);
                 section_list(ui, "Sectors", &galaxy.sector_lines);
                 section_list(ui, "Stations", &galaxy.station_lines);
                 section_list(ui, "Jumpgates", &galaxy.gate_lines);

--- a/client-admin/src/stdb/connector.rs
+++ b/client-admin/src/stdb/connector.rs
@@ -121,7 +121,11 @@ fn subscribe_to_tables(ctx: &DbConnection) {
             "SELECT * FROM sector",
             "SELECT * FROM faction",
             "SELECT * FROM station",
+            "SELECT * FROM station_under_construction",
             "SELECT * FROM jump_gate",
             "SELECT * FROM item_definition",
+            // Live-state snapshot tables for the read-only galaxy overview (#145).
+            "SELECT * FROM player",
+            "SELECT * FROM ship",
         ]);
 }


### PR DESCRIPTION
First increment of #145, per the [scope-lock comment](https://github.com/GalaxyCr8r/solarance-beginnings/issues/145#issuecomment-4773819448). Read-only galaxy overview built **inside the existing `client-admin` app**, reusing its owner-token connection/auth unchanged — no new auth work, no reducers, no mutation.

## What

- **Subscriptions** (`stdb/connector.rs`): added `player`, `ship`, and `station_under_construction` to the snapshot subscription.
- **Galaxy panel** (`app.rs`) — three additions to the right-hand listing:
  - **Players** — username · abbreviated identity · online/offline (`logged_in`) · faction name · credits · last-login.
  - **Ships** — grouped by sector (sector_id then id): location, ship type, owner identity.
  - **Stations** — existing line now gains a `[building N%]` suffix while a matching `station_under_construction` site is in progress.
- Summary header now counts players + ships too. Empty sections render `(none)` via the existing `section_list` helper.

## Test

`cargo check` + `cargo build` clean. To exercise:
1. `spacetime start` and publish the module (seed gives sectors/stations).
2. `task client-admin:run` (or `cargo run` in `client-admin/`).
3. Connect to the host with the **module owner token**.
4. The right panel's **Players / Ships / Stations** sections populate. Players/ships appear once someone has played; stations + `[building %]` show from the seed immediately.

## Scope

Increment 2 (player-picker + `admin_send_direct_server_message` with the `MessageSeverity` enum) is deliberately **not** here — it stays in #145 as the second checkbox, to be picked up when the enum-arg reducer actually blocks a playtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)