### PR TITLE
devlog: June monthly update — M3 closed, M4 underway

### DIFF
--- a/docs/devlog/006-two-factions-ten-sectors.md
+++ b/docs/devlog/006-two-factions-ten-sectors.md
@@ -1,0 +1,25 @@
+---
+slug: 006-two-factions-ten-sectors
+date: 2026-06-30
+tag: DEVLOG · 006
+title: Two factions, ten sectors, one real map.
+tags: [m3, m4, factions, map, messaging]
+---
+
+June was the month M3 actually closed, and I didn't stop to celebrate before M4 was already half-seeded.
+
+## What's actually in
+
+**Messaging got untangled first.** The old chat/server-message setup was two systems answering the same question — who should see this? — in incompatible ways. Replaced both with six tables: five Channel Messages (Server, Galaxy, StarSystem, Sector, Faction — pick your audience) and one Direct Server Message inbox for things the server needs to tell one player later, like the welcome-back summary. Net -947 lines. Wrote the reasoning up as ADR-0001 if you want more than the diff.
+
+**M3 closed.** New players now pick Lrak Combine or Rediar Federation — the only two factions with a Capital station, so the picker greys out anything that isn't real yet — and spawn at their faction's capital in a single Column corvette, one ship per player, enforced server-side. Construction sites tint by owning faction now too, so you can tell whose site you're looking at without reading a tooltip. Chasing a bug where the welcome-back panel vanished for docked players (#149) turned into ADR-0002: docking doesn't "pause" a ship, it structurally removes it from the sector simulation. Piloted Ship vs. Docked Ship is vocabulary now, not just behavior.
+
+**M4 started before M3's paint dried.** Procyon is ten sectors now instead of four — two faction capitals bracketing a neutral middle, connected by a real hub-and-spoke jumpgate network, five sectors minable. Built a small admin-only client (`client-admin`) to seed and inspect all of that without hand-writing SQL, and it already does more than seeding — this week it grew a read-only galaxy overview: players, ships, and construction sites at a glance. The in-game map got jumpgate lines, always-on labels, and auto-fit so the whole network is legible instead of an arbitrary crop.
+
+**The website map stopped being a mock.** It now queries SpacetimeDB's public HTTP /sql endpoint directly — no SDK, no build step — so what you see on the site is the actual galaxy, not a screenshot pretending to be one.
+
+**Small stuff that mattered:** asteroid fields now have per-sector ore mixes instead of one global table (Karren's Reach finally has Carbon, which the old global table never spawned); killed a 100ms combat-cooldown timer that turned out to be the single biggest CPU cost on the live maincloud instance, for a system that isn't even in scope yet; fixed a jumpgate-transit flicker where ships from the wrong sector would ghost into view for a frame.
+
+## What's next
+
+M4's exit gate: jumpgate connectivity verified across all ten sectors, decorative nebulae, and the admin client covering the rest of the seed/inspect workflow. After that I want actual bodies in more than one sector at once — the M1 question, whether watching the bar move together feels like anything, still hasn't been answered with more than two people in the same place.

--- a/docs/devlog/index.json
+++ b/docs/devlog/index.json
@@ -1,4 +1,5 @@
 [
+  "006-two-factions-ten-sectors",
   "005-the-bar-moved",
   "004-cutting-mvp-back-again",
   "003-rotational-velocity",


### PR DESCRIPTION
## Summary
- Adds `docs/devlog/006-two-factions-ten-sectors.md`, a monthly recap of everything that landed on `main` in June.
- Covers the messaging redesign (6-table Channel Message / Direct Server Message split), M3 closing out (faction picker hard-capped to Lrak Combine / Rediar Federation, capital-sector spawn, one-ship guard, faction-tinted construction sites, the docking ADR), M4 kicking off (ten-sector Procyon seed, the new `client-admin` tool, in-game map polish), the website System Map going live off real SpacetimeDB data, and the perf/cleanup pass (killing the combat-cooldown timer, per-sector ore composition, jumpgate flicker fix).
- Registers the new post at the top of `docs/devlog/index.json`.

## Test plan
- [x] Verified the post's Markdown only uses syntax supported by the site's tiny renderer (`##` headings, `**bold**`, inline `` `code` ``).
- [x] Confirmed `docs/devlog/index.json` is the manifest actually read by `docs/devlog.jsx` (the legacy `posts.json` is unused).
- [ ] Visual check on the deployed site once merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Byk86k2y2bf2mCS1LNHJy7)_