### PR TITLE
feat: decorative in-sector nebulae from seeded X/Y data (#107)

### DIFF
--- a/client/src/gameplay/render.rs
+++ b/client/src/gameplay/render.rs
@@ -34,6 +34,15 @@ pub fn sector(game_state: &mut GameState) {
     // out-of-play, in which case we don't filter (nothing to anchor to).
     let player_sector = player_ship.as_ref().map(|s| s.sector_id);
 
+    // Decorative nebulae (#107) — drawn first so every real object sits on top.
+    // Same wrong-sector filter as the stellar-object pass below.
+    for nebula in db.sector_nebula().iter() {
+        if player_sector.is_some_and(|ps| nebula.sector_id != ps) {
+            continue;
+        }
+        draw_nebula(&nebula);
+    }
+
     // Collect ships to draw after stations
     let mut ships_to_draw: Vec<(Ship, RenderPose, ShipTypeDefinition)> = Vec::new();
 

--- a/client/src/gameplay/render/in_sector.rs
+++ b/client/src/gameplay/render/in_sector.rs
@@ -224,6 +224,29 @@ pub fn draw_ship(
     }
 }
 
+/// Decorative in-sector nebula (#107). Pure flavor: no pose, no radar entry,
+/// no targeting — drawn under everything else in the sector pass.
+pub fn draw_nebula(nebula: &SectorNebula) {
+    let resources = storage::get::<Resources>();
+    let Some(tex) = resources.nebula_textures.get(nebula.gfx_key.as_str()) else {
+        return; // Unknown key — decorative, so silently skip rather than panic.
+    };
+    let w = tex.width() * nebula.scale;
+    let h = tex.height() * nebula.scale;
+    let t = nebula.tint; // 0xRRGGBBAA
+    draw_texture_ex(
+        tex,
+        nebula.position.x - w * 0.5,
+        nebula.position.y - h * 0.5,
+        Color::from_rgba((t >> 24) as u8, (t >> 16) as u8, (t >> 8) as u8, t as u8),
+        DrawTextureParams {
+            rotation: nebula.rotation_radians,
+            dest_size: Some(vec2(w, h)),
+            ..DrawTextureParams::default()
+        },
+    );
+}
+
 pub fn draw_asteroid(pose: &RenderPose, asteroid: Asteroid, game_state: &mut GameState) {
     let resources = storage::get::<Resources>();
     let position = pose.pos;

--- a/client/src/stdb/connector/subscriptions.rs
+++ b/client/src/stdb/connector/subscriptions.rs
@@ -66,6 +66,14 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
         WHERE s.player_id = '{}'",
         ctx.identity()
     );
+    // Decorative in-sector nebulae (#107) — static flavor rows, current sector only.
+    let sector_nebula = format!(
+        "SELECT n.*
+        FROM sector_nebula n
+        JOIN ship s ON s.sector_id = n.sector_id
+        WHERE s.player_id = '{}'",
+        ctx.identity()
+    );
     let cargo_crate = format!(
         "SELECT c.* 
         FROM cargo_crate c
@@ -114,6 +122,7 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
             "SELECT * FROM star_system",
             "SELECT * FROM star_system_object",
             "SELECT * FROM sector",
+            sector_nebula.as_str(),
             //"SELECT * FROM asteroid_sector",
             "SELECT * FROM ship_type_definition",
             "SELECT * FROM ship_status",

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -56,6 +56,7 @@ fn demo_sectors(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     setup_sector_connections(dsl, &sectors)?;
     populate_sectors_with_asteroids(dsl, &sectors)?;
     create_sector_stations(dsl, &sectors, &lrak, &rediar, &iwa)?;
+    place_sector_nebulae(dsl, &sectors)?;
     Ok(())
 }
 
@@ -445,6 +446,48 @@ fn create_sector_stations(
             ResourceAmount::new(ITEM_GOLD_ORE, 50),
         ],
     )?;
+
+    Ok(())
+}
+
+/// Seeds decorative in-sector nebulae (#107). The Hinge sits inside the
+/// system's nebula belt (orbit_au 12.0) and gets significant coverage;
+/// Lrakhold and Echo Bay each get a single wisp. Pure render flavor —
+/// nothing reads these rows server-side.
+fn place_sector_nebulae(
+    dsl: &DSL<'_, ReducerContext>,
+    s: &ProcyonSectors,
+) -> Result<(), String> {
+    let nebula = |sector: &Sector,
+                  x: f32,
+                  y: f32,
+                  gfx_key: &str,
+                  scale: f32,
+                  rotation_deg: f32,
+                  tint: u32|
+     -> Result<(), String> {
+        dsl.create_sector_nebula(CreateSectorNebula {
+            sector_id: sector.get_id(),
+            position: Vec2::new(x, y),
+            gfx_key: gfx_key.to_string(),
+            scale,
+            rotation_radians: rotation_deg.to_radians(),
+            tint,
+        })
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+    };
+
+    // The Hinge — the only sector within the nebula belt; blanket it.
+    nebula(&s.the_hinge, -2600.0, 1900.0, "nebula.1", 6.0, 20.0, 0xFFFFFFA0)?;
+    nebula(&s.the_hinge, 1400.0, -2300.0, "nebula.1", 5.0, 140.0, 0xE0E8FF90)?;
+    nebula(&s.the_hinge, 3300.0, 1000.0, "nebula.1", 4.0, 275.0, 0xFFFFFF80)?;
+    nebula(&s.the_hinge, -900.0, -3400.0, "nebula.1", 4.5, 65.0, 0xD8E0FF88)?;
+    nebula(&s.the_hinge, 400.0, 2900.0, "nebula.1", 3.5, 200.0, 0xFFFFFF70)?;
+
+    // Single wisps on the belt-adjacent capitals.
+    nebula(&s.lrakhold, 2800.0, -1600.0, "nebula.7", 4.0, 310.0, 0xFFFFFF90)?;
+    nebula(&s.echo_bay, -2200.0, 2400.0, "nebula.6", 4.0, 45.0, 0xFFFFFF90)?;
 
     Ok(())
 }

--- a/server/src/tables/sectors.rs
+++ b/server/src/tables/sectors.rs
@@ -1,3 +1,4 @@
+use solarance_shared::Vec2;
 use spacetimedb::{table, SpacetimeType};
 use spacetimedsl::*;
 
@@ -20,6 +21,7 @@ pub struct Sector {
     #[referenced_by(path = crate::tables::combat, table = visual_effect)]
     #[referenced_by(path = crate::tables::messages, table = sector_channel_message)]
     #[referenced_by(path = crate::tables::items, table = cargo_crate)]
+    #[referenced_by(path = crate::tables::sectors, table = sector_nebula)]
     id: u64,
 
     #[index(btree)]
@@ -92,6 +94,33 @@ pub struct AsteroidSector {
     /// weighted by this list (ignoring `rarity`); when empty it falls back to
     /// the global rarity-skewed distribution. See `asteroid_fields::roll_ore_item`.
     ore_weights: Vec<OreWeight>,
+}
+
+/// Decorative in-sector nebula sprite (#107). Pure render flavor — no stellar
+/// object, no collision, no game mechanic. Ships fly straight through them.
+#[dsl(plural_name = sector_nebulae, method(update = false))]
+#[table(accessor = sector_nebula, public)]
+pub struct SectorNebula {
+    #[primary_key]
+    #[auto_inc]
+    #[create_wrapper]
+    id: u64,
+
+    #[index(btree)] // To find nebulae in a specific sector
+    #[use_wrapper(SectorId)]
+    #[foreign_key(path = crate::tables::sectors, table = sector, column = id, on_delete = Delete)]
+    /// FK to Sector
+    sector_id: u64,
+
+    /// World-space position of the sprite center. Static — nebulae don't move.
+    position: Vec2,
+    /// Client texture key, e.g. "nebula.1"
+    gfx_key: String,
+    /// Sprite scale multiplier applied to the texture's native size
+    scale: f32,
+    rotation_radians: f32,
+    /// Packed 0xRRGGBBAA tint the client multiplies the texture by
+    tint: u32,
 }
 
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #107.

## What

- **Server:** new `SectorNebula` table in `tables/sectors.rs` — `sector_id` FK, `position`, `gfx_key`, `scale`, `rotation_radians`, packed RGBA `tint` (per the triage answer: yes to scale/rotation/tint per instance). No stellar object — pure decoration, nothing server-side reads these rows.
- **Server:** seeded in `definitions/galaxy.rs` per the issue comments: The Hinge (inside the nebula belt) gets five `nebula.1` wisps blanketing the sector; Lrakhold gets a single `nebula.7`; Echo Bay a single `nebula.6`.
- **Client:** subscribes to the current sector's `sector_nebula` rows (same join pattern as asteroids) and draws them first in the sector pass, so ships/stations/asteroids all render on top. No radar entry, no targeting, no mechanic.

## Verified

- Server module + client both build.
- Published to a scratch local DB: init seeds 7 rows (5× Hinge, 1× Lrakhold, 1× Echo Bay), no errors in logs; scratch DB deleted after.
- In-game visual check still pending — worth a screenshot pass in The Hinge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)