### PR TITLE
feat(map): click details panel, construction indicators, faction tinting (#121)

### DIFF
--- a/client/src/gameplay/gui/map_window.rs
+++ b/client/src/gameplay/gui/map_window.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use egui::*;
 use macroquad::prelude::*;
@@ -29,6 +29,21 @@ pub struct State {
     /// Accumulated pan offset (screen px) from dragging the galaxy map canvas.
     /// Reset by the "Recenter" button. Zoom is intentionally not supported (#120).
     pan: egui::Vec2,
+
+    /// Sector selected by clicking its dot (#121); drives the details side
+    /// panel. Clicking empty canvas clears it.
+    selected_sector_id: Option<u64>,
+}
+
+/// Faction tint for map sector dots (#121). IDs are locked by the M3 seed:
+/// FACTION_LRAK_COMBINE = 1, FACTION_REDIAR_FEDERATION = 4 (see
+/// `server/src/definitions/factions.rs`). Everything else renders desaturated.
+fn faction_color(faction_id: u32) -> Color32 {
+    match faction_id {
+        1 => Color32::from_rgb(214, 92, 66),  // Lrak Combine — rust red
+        4 => Color32::from_rgb(86, 148, 216), // Rediar Federation — federation blue
+        _ => Color32::from_gray(140),         // neutral / other
+    }
 }
 
 impl State {
@@ -39,6 +54,8 @@ impl State {
             stroke: Stroke::new(2.0, Color32::from_rgb(25, 200, 100)),
 
             pan: egui::Vec2::ZERO,
+
+            selected_sector_id: None,
         }
     }
 
@@ -95,6 +112,14 @@ impl State {
         });
 
         ui.separator();
+
+        // Sectors with active builds — derived fresh each frame from the
+        // subscribed tables, so the indicators and panel update live (#121).
+        let construction_sectors = sectors_with_active_construction(ctx);
+
+        // Details side panel for the clicked sector — drawn before the canvas
+        // so the canvas consumes the remaining width.
+        self.draw_sector_details(ui, ctx, &construction_sectors);
 
         Frame::canvas(ui.style()).show(ui, |ui| {
             let (response, painter) = ui.allocate_painter(
@@ -219,31 +244,76 @@ impl State {
             // Build the dot shapes now; labels are drawn last so they sit on
             // top of every other layer.
             let hover = response.hover_pos();
+            let time = ui.input(|i| i.time) as f32;
+            let corners = CornerRadius {
+                nw: 0,
+                ne: 4,
+                sw: 4,
+                se: 4,
+            };
             let mut sector_screens: Vec<(&Sector, Pos2)> = Vec::with_capacity(sectors.len());
             for sector in &sectors {
                 let center = to_screen(sector.x, sector.y);
                 sector_screens.push((sector, center));
 
+                // Faction tint (#121): faint faction fill on every dot; the
+                // current sector keeps its green "you are here" stroke on top.
+                let tint = faction_color(sector.controlling_faction_id);
                 let stroke = if current_sector.id == sector.id {
                     self.stroke // preserved green highlight for the current sector
                 } else {
-                    Stroke::new(1.5, Color32::from_gray(180))
+                    Stroke::new(1.5, tint)
                 };
                 let rect = egui::Rect::from_center_size(
                     center,
                     egui::Vec2::splat(2.0 * MAP_SECTOR_RADIUS),
                 );
-                markers.push(Shape::rect_stroke(
+                markers.push(Shape::rect_filled(
                     rect,
-                    CornerRadius {
-                        nw: 0,
-                        ne: 4,
-                        sw: 4,
-                        se: 4,
-                    },
-                    stroke,
-                    StrokeKind::Middle,
+                    corners,
+                    Color32::from_rgba_unmultiplied(tint.r(), tint.g(), tint.b(), 48),
                 ));
+                markers.push(Shape::rect_stroke(rect, corners, stroke, StrokeKind::Middle));
+
+                // Ring around the sector the details panel is showing.
+                if self.selected_sector_id == Some(sector.id) {
+                    markers.push(Shape::rect_stroke(
+                        rect.expand(3.0),
+                        corners,
+                        Stroke::new(1.0, Color32::WHITE),
+                        StrokeKind::Middle,
+                    ));
+                }
+
+                // Construction-site indicator (#121): slow amber pulse ring.
+                if construction_sectors.contains(&sector.id) {
+                    let pulse = 0.5 + 0.5 * (time * 2.5).sin();
+                    markers.push(Shape::circle_stroke(
+                        center,
+                        MAP_SECTOR_RADIUS + 4.0 + 3.0 * pulse,
+                        Stroke::new(
+                            1.5,
+                            Color32::from_rgba_unmultiplied(
+                                255,
+                                176,
+                                64,
+                                (90.0 + 130.0 * pulse) as u8,
+                            ),
+                        ),
+                    ));
+                }
+            }
+
+            // Click → select the dot under the pointer; clicking empty canvas
+            // clears the selection. egui only reports `clicked()` when the
+            // press wasn't a drag, so panning never changes the selection.
+            if response.clicked() {
+                if let Some(click) = response.interact_pointer_pos() {
+                    self.selected_sector_id = sector_screens
+                        .iter()
+                        .find(|(_, center)| (click - *center).length() <= MAP_SECTOR_RADIUS + 4.0)
+                        .map(|(sector, _)| sector.id);
+                }
             }
 
             // Paint in z-order: backdrop, edges, sector dots.
@@ -273,6 +343,79 @@ impl State {
                 }
             }
         });
+    }
+
+    /// Right-hand details panel for the clicked sector (#121): name, coords,
+    /// controlling faction, security, description, and the adjacent-sector
+    /// list derived from `jump_gate` edges (links re-target the panel). If the
+    /// selected row vanishes from the cache the selection silently clears.
+    fn draw_sector_details(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &DbConnection,
+        construction_sectors: &HashSet<u64>,
+    ) {
+        let Some(selected_id) = self.selected_sector_id else {
+            return;
+        };
+        let Some(sector) = ctx.db().sector().id().find(&selected_id) else {
+            self.selected_sector_id = None;
+            return;
+        };
+
+        egui::SidePanel::right("map_sector_details")
+            .resizable(false)
+            .exact_width(190.0)
+            .show_inside(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading(&sector.name);
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.small_button("✕").clicked() {
+                            self.selected_sector_id = None;
+                        }
+                    });
+                });
+                ui.weak(format!("({:.0}, {:.0})", sector.x, sector.y));
+                ui.separator();
+
+                let faction_text = ctx
+                    .db()
+                    .faction()
+                    .id()
+                    .find(&sector.controlling_faction_id)
+                    .map(|f| format!("{} [{}]", f.name, f.short_name))
+                    .unwrap_or_else(|| format!("Faction #{}", sector.controlling_faction_id));
+                ui.colored_label(faction_color(sector.controlling_faction_id), faction_text);
+                ui.label(format!("Security: {} / 10", sector.security_level));
+                if construction_sectors.contains(&sector.id) {
+                    ui.colored_label(
+                        Color32::from_rgb(255, 176, 64),
+                        "⚠ Station under construction",
+                    );
+                }
+
+                if let Some(description) = &sector.description {
+                    ui.separator();
+                    ui.label(description);
+                }
+
+                ui.separator();
+                ui.strong("Connected sectors");
+                // Gates are bidirectional (two rows per pair); collecting the
+                // outbound targets into a BTreeSet dedups and sorts stably.
+                let adjacent: BTreeSet<u64> = ctx
+                    .db()
+                    .jump_gate()
+                    .iter()
+                    .filter(|gate| gate.current_sector_id == sector.id)
+                    .map(|gate| gate.target_sector_id)
+                    .collect();
+                for adjacent_id in adjacent {
+                    if ui.link(get_sector_name(ctx, &adjacent_id)).clicked() {
+                        self.selected_sector_id = Some(adjacent_id);
+                    }
+                }
+            });
     }
 }
 

--- a/client/src/gameplay/gui/map_window.rs
+++ b/client/src/gameplay/gui/map_window.rs
@@ -411,7 +411,23 @@ impl State {
                     .map(|gate| gate.target_sector_id)
                     .collect();
                 for adjacent_id in adjacent {
-                    if ui.link(get_sector_name(ctx, &adjacent_id)).clicked() {
+                    // Cross-system gates carry the destination system in
+                    // front of the sector name, e.g. "[Kingdom's End] Spacefalls".
+                    let label = match ctx.db().sector().id().find(&adjacent_id) {
+                        Some(adj) if adj.system_id != sector.system_id => {
+                            let system_name = ctx
+                                .db()
+                                .star_system()
+                                .id()
+                                .find(&adj.system_id)
+                                .map(|s| s.name)
+                                .unwrap_or_else(|| format!("#{}", adj.system_id));
+                            format!("[{}] {}", system_name, adj.name)
+                        }
+                        Some(adj) => adj.name,
+                        None => format!("Sector #{}", adjacent_id),
+                    };
+                    if ui.link(label).clicked() {
                         self.selected_sector_id = Some(adjacent_id);
                     }
                 }

--- a/client/src/gameplay/gui/map_window.rs
+++ b/client/src/gameplay/gui/map_window.rs
@@ -130,8 +130,17 @@ impl State {
             // Pan the whole map by dragging anywhere on the canvas.
             self.pan += response.drag_delta();
 
-            // Collect sectors once; bail if the world hasn't loaded yet.
-            let sectors: Vec<Sector> = ctx.db().sector().iter().collect();
+            // Collect the *current system's* sectors only — the galaxy holds
+            // more than one system, and this is the system map. Cross-system
+            // gate edges drop out automatically (their far end never lands in
+            // `positions`); the details panel still lists them with a
+            // "[System] Sector" prefix. Bail if the world hasn't loaded yet.
+            let sectors: Vec<Sector> = ctx
+                .db()
+                .sector()
+                .iter()
+                .filter(|s| s.system_id == current_sector.system_id)
+                .collect();
             if sectors.is_empty() {
                 return;
             }

--- a/client/src/gameplay/resources.rs
+++ b/client/src/gameplay/resources.rs
@@ -29,7 +29,7 @@ impl Resources {
         info!("Loading textures...");
 
         resources.sun_textures.insert("star.1", load_linear_sprite("stars/star.png").await?);
-        //resources.sun_textures.insert("star.2", load_linear_sprite("stars/star02.png").await?);
+        resources.sun_textures.insert("star.2", load_linear_sprite("stars/star02.png").await?);
 
         resources.planet_textures.insert(
             "planet.1",
@@ -38,6 +38,10 @@ impl Resources {
         resources.planet_textures.insert(
             "planet.2",
             load_linear_sprite("planets/GasGiant1.png").await?
+        );
+        resources.planet_textures.insert(
+            "planet.3",
+            load_linear_sprite("planets/desertplanet2.png").await?
         );
         resources.planet_textures.insert(
             "planet.shadow.1",

--- a/client/src/stdb/utils.rs
+++ b/client/src/stdb/utils.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use macroquad::{miniquad::date::now, prelude::glam};
 use spacetimedb_sdk::{DbContext, Identity, Table};
 
@@ -165,6 +167,18 @@ pub fn station_display_name(ctx: &DbConnection, station: &Station) -> String {
         Some(_) => format!("{} (Under Construction)", station.name),
         None => station.name.clone(),
     }
+}
+
+/// IDs of every sector containing at least one active (not yet operational)
+/// construction site. Domain query per the client architecture review §5 —
+/// the map window's build indicators read this instead of joining inline.
+pub fn sectors_with_active_construction(ctx: &DbConnection) -> HashSet<u64> {
+    ctx.db()
+        .station_under_construction()
+        .iter()
+        .filter(|uc| !uc.is_operational)
+        .filter_map(|uc| ctx.db().station().id().find(&uc.id).map(|s| s.sector_id))
+        .collect()
 }
 
 pub fn get_sector_name(ctx: &DbConnection, id: &u64) -> String {

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -57,6 +57,12 @@ fn demo_sectors(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     populate_sectors_with_asteroids(dsl, &sectors)?;
     create_sector_stations(dsl, &sectors, &lrak, &rediar, &iwa)?;
     place_sector_nebulae(dsl, &sectors)?;
+
+    // Omicron — the second star system (#121). One cross-system gate out of
+    // The Hinge exercises every multi-system code path (system-map filtering,
+    // "[System] Sector" gate labels, cross-system travel).
+    let omicron = seed_omicron_system(dsl, &neutral)?;
+    connect_sectors_with_warpgates(dsl, &sectors.the_hinge, &omicron.dark_sun)?;
     Ok(())
 }
 
@@ -490,6 +496,98 @@ fn place_sector_nebulae(
     nebula(&s.echo_bay, -2200.0, 2400.0, "nebula.6", 4.0, 45.0, 0xFFFFFF90)?;
 
     Ok(())
+}
+
+/// The Omicron sectors, mirrored from `ProcyonSectors` so future wiring reads
+/// the same way. Sector IDs continue after Procyon's 0..9.
+struct OmicronSectors {
+    dark_sun: Sector, // 10 — factionless, the lightless inner sector
+    ashfall: Sector,  // 11 — factionless, dim outer ember
+}
+
+/// Seeds the Omicron star system (#121): a dim M-dwarf neighbor of Procyon
+/// holding two factionless frontier sectors, wired to each other by a normal
+/// gate. Kept as structured as the Procyon seed so multi-system testing
+/// (map filtering, cross-system labels, travel) has a real second system to
+/// lean on. The cross-system gate (Dark Sun <-> The Hinge) is wired by
+/// `demo_sectors`, next to the rest of the gate network.
+fn seed_omicron_system(
+    dsl: &DSL<'_, ReducerContext>,
+    neutral: &FactionId,
+) -> Result<OmicronSectors, String> {
+    let omicron = dsl.create_star_system(CreateStarSystem {
+        name: "Omicron".to_string(),
+        map_coordinates: Vec2::new(21.0, 34.0),
+        spectral: SpectralKind::M,
+        luminosity: 6,
+        controlling_faction_id: neutral.clone(),
+    })?;
+
+    let _star = dsl.create_star_system_object(CreateStarSystemObject {
+        system_id: omicron.get_id(),
+        kind: StarSystemObjectKind::Star,
+        orbit_au: 0.0,
+        rotation_or_width_km: 0.0,
+        gfx_key: Some("star.1".to_string()),
+    });
+    let _planet = dsl.create_star_system_object(CreateStarSystemObject {
+        system_id: omicron.get_id(),
+        kind: StarSystemObjectKind::Planet,
+        orbit_au: 60.0,
+        rotation_or_width_km: (210f32).to_radians(),
+        gfx_key: Some("planet.2".to_string()),
+    });
+    let _nebbelt = dsl.create_star_system_object(CreateStarSystemObject {
+        system_id: omicron.get_id(),
+        kind: StarSystemObjectKind::NebulaBelt,
+        orbit_au: 30.0,
+        rotation_or_width_km: 14.0,
+        gfx_key: None,
+    });
+
+    // Same one-line-per-sector helper shape as `create_procyon_sectors`,
+    // plus a description so the map details panel's description path has
+    // seeded data to render.
+    let mk = |id: u64,
+              name: &str,
+              description: Option<&str>,
+              security: u8,
+              sunlight: f32,
+              anomalous: f32,
+              nebula: f32,
+              rare_ore: f32,
+              x: f32,
+              y: f32|
+     -> Result<Sector, String> {
+        dsl.create_sector(CreateSector {
+            id,
+            system_id: omicron.get_id(),
+            name: name.to_string(),
+            description: description.map(str::to_string),
+            controlling_faction_id: neutral.clone(),
+            security_level: security,
+            sunlight,
+            anomalous,
+            nebula,
+            rare_ore,
+            x,
+            y,
+            background_gfx_key: None,
+        })
+        .map_err(|e| e.to_string())
+    };
+
+    let dark_sun = mk(
+        10,
+        "Dark Sun",
+        Some("Omicron's failing ember barely reaches this sector. Sensor returns are unreliable, and nobody polices what they can't see."),
+        1, 0.1, 0.6, 0.3, 0.3, 0.0, 0.0,
+    )?;
+    let ashfall = mk(11, "Ashfall", None, 1, 0.2, 0.3, 0.2, 0.4, 45.0, 20.0)?;
+
+    connect_sectors_with_warpgates(dsl, &dark_sun, &ashfall)?;
+
+    Ok(OmicronSectors { dark_sun, ashfall })
 }
 
 /// Stamps a station as the faction's capital — the spawn anchor for that

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -51,18 +51,19 @@ fn demo_sectors(dsl: &DSL<'_, ReducerContext>) -> Result<(), String> {
     let iwa = FactionId::new(FACTION_INDEPENDENT_WORLDS_ALLIANCE);
 
     let procyon = create_procyon_star_system(dsl, &lrak)?;
-    let sectors = create_procyon_sectors(dsl, &procyon, &lrak, &rediar, &neutral)?;
+    let procyon_sectors = create_procyon_sectors(dsl, &procyon, &lrak, &rediar, &neutral)?;
 
-    setup_sector_connections(dsl, &sectors)?;
-    populate_sectors_with_asteroids(dsl, &sectors)?;
-    create_sector_stations(dsl, &sectors, &lrak, &rediar, &iwa)?;
-    place_sector_nebulae(dsl, &sectors)?;
+    setup_sector_connections(dsl, &procyon_sectors)?;
+    populate_sectors_with_asteroids(dsl, &procyon_sectors)?;
+    create_sector_stations(dsl, &procyon_sectors, &lrak, &rediar, &iwa)?;
+    place_sector_nebulae(dsl, &procyon_sectors)?;
 
     // Omicron — the second star system (#121). One cross-system gate out of
     // The Hinge exercises every multi-system code path (system-map filtering,
     // "[System] Sector" gate labels, cross-system travel).
-    let omicron = seed_omicron_system(dsl, &neutral)?;
-    connect_sectors_with_warpgates(dsl, &sectors.the_hinge, &omicron.dark_sun)?;
+    let omicron_sectors = seed_omicron_system(dsl, &neutral)?;
+    connect_sectors_with_warpgates(dsl, &procyon_sectors.the_hinge, &omicron_sectors.dark_sun)?;
+
     Ok(())
 }
 
@@ -528,14 +529,14 @@ fn seed_omicron_system(
         kind: StarSystemObjectKind::Star,
         orbit_au: 0.0,
         rotation_or_width_km: 0.0,
-        gfx_key: Some("star.1".to_string()),
+        gfx_key: Some("star.2".to_string()),
     });
     let _planet = dsl.create_star_system_object(CreateStarSystemObject {
         system_id: omicron.get_id(),
         kind: StarSystemObjectKind::Planet,
         orbit_au: 60.0,
         rotation_or_width_km: (210f32).to_radians(),
-        gfx_key: Some("planet.2".to_string()),
+        gfx_key: Some("planet.3".to_string()),
     });
     let _nebbelt = dsl.create_star_system_object(CreateStarSystemObject {
         system_id: omicron.get_id(),


### PR DESCRIPTION
Closes #121. Client-only, builds on the #120 canvas.

## What

- **Click a sector → details panel.** Clicking a dot opens a right-hand side panel inside the map window: sector name + coordinates, controlling faction (name + `[short tag]`, tinted), security `N / 10`, `description` when present, and the adjacent-sector list derived from `jump_gate` edges (deduped; each entry is a link that re-targets the panel). Clicking empty canvas or ✕ closes it; panning never changes selection (egui separates click from drag).
- **Construction-site indicators.** Sectors with at least one non-operational `station_under_construction` row get a slow amber pulse ring around their dot, plus a ⚠ line in the details panel. The sector set is re-derived from the subscribed tables every frame, so it updates live with no refresh. The query lives in `stdb/utils.rs` (`sectors_with_active_construction`) per the Client Architecture Review §5 pointer, not inline in the map window.
- **Faction-tinted dots.** Faint faction fill + faction stroke per dot: Lrak Combine rust red, Rediar Federation federation blue, neutral/other desaturated gray. Faction IDs are the M3-locked seed constants (1 / 4). The current sector keeps its green "you are here" stroke regardless of tint; the selected sector gets a thin white ring.

## Out of scope (per issue)

No route planning, no zoom, galaxy tab untouched.

## Verified

- Client builds clean (no new warnings).
- Visual pass pending — worth clicking around the map with a construction site active (Karren's Reach / Iron Furrow are seeded under construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)