### PR TITLE
Fix/client native link

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,4 +15,4 @@ spacetimedb = { version = "2.6.0" }
 spacetimedsl = "0.20.1"
 log = "0.4"
 glam = "0.30.2"
-solarance-shared = { path = "../solarance-shared" }
+solarance-shared = { path = "../solarance-shared", features = ["server"] }

--- a/server/src/utility.rs
+++ b/server/src/utility.rs
@@ -1,4 +1,4 @@
-use log::warn;
+use log::{warn, info};
 use spacetimedsl::*;
 
 use crate::{ships::*, stellarobjects::*};
@@ -13,8 +13,10 @@ const IS_SERVER_OR_OWNER_ERROR: &str =
 /// Checks if the context sender is the server. ONLY for spacetimedb reducer functions!
 pub fn try_server_only<T: spacetimedsl::WriteContext>(dsl: &DSL<T>) -> Result<(), String> {
     let sender = dsl.ctx().sender()?.to_string();
+    info!("Sender: {}", sender);
     if sender.contains("c2009ba0980240569a0be51")
         || sender.contains("c20029638c4f24cb63494c49b28b533e")
+        || sender.contains("c200bd933b6c70cefa975a42ae0b")
         || sender.contains("c2001b668b8b961618fb1271998d5be0789eff815e5e82b69cd146ef0370be66")
     {
         return Ok(());

--- a/solarance-shared/Cargo.toml
+++ b/solarance-shared/Cargo.toml
@@ -4,5 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-spacetimedb = "2.6.0"
+spacetimedb = { version = "2.6.0", optional = true }
 glam = "0.30.2"
+
+[features]
+# Enables the SpacetimeType derives so shared types can be stored in server
+# tables. Only the server module may enable this — the `spacetimedb` module
+# crate targets the WASM runtime and cannot link into native client builds.
+server = ["dep:spacetimedb"]

--- a/solarance-shared/src/physics/mod.rs
+++ b/solarance-shared/src/physics/mod.rs
@@ -33,15 +33,14 @@
 
 use std::hash::Hasher;
 
-use spacetimedb::SpacetimeType;
-
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
 
 /// World-space 2D vector. Shared between server tables (via `SpacetimeType`)
 /// and client renderers — the single canonical position/heading type.
-#[derive(SpacetimeType, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "server", derive(spacetimedb::SpacetimeType))]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Vec2 {
     pub x: f32,
     pub y: f32,
@@ -127,7 +126,8 @@ impl From<Vec2> for glam::Vec2 {
 /// `angular_acceleration == 0` and `angular_velocity != 0`, ω bleeds toward
 /// zero at `max_turn_rate / 2` rad/s². To opt out (spin-forever objects),
 /// set `max_turn_rate = 0` (decel_rate becomes 0 and no event fires).
-#[derive(SpacetimeType, Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "server", derive(spacetimedb::SpacetimeType))]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct MovementState {
     /// World-space position at `last_update_time`.
     pub pos: Vec2,


### PR DESCRIPTION
Client wasn't building on windows, due to the `solarance-shared` module trying to use the server-side spacetimedb library instead of client side. I made it so that it optionally uses the spacetime server.