### PR TITLE
feat(client): warn on client/server version mismatch at login

### DIFF
--- a/client/src/login.rs
+++ b/client/src/login.rs
@@ -425,19 +425,19 @@ pub async fn loading_screen(token: Option<String>) -> Option<DbConnection> {
     return connection;
 }
 
-/// Compares this binary's version against the server's (written to the
-/// `global_config` table at init) and, on mismatch, asks the player whether to
+/// Compares this binary's version against the server's (exposed via the
+/// `public_global_config` view) and, on mismatch, asks the player whether to
 /// continue. Returns `true` to proceed into the game, `false` to abort to the menu.
 ///
-/// The `global_config` row arrives via subscription shortly after connect, so we
-/// poll a few seconds for it; if it never shows we proceed rather than block the
-/// player on a check we can't complete.
+/// The view row arrives via subscription shortly after connect, so we poll a few
+/// seconds for it; if it never shows we proceed rather than block the player on a
+/// check we can't complete.
 async fn confirm_version_match(connection: &DbConnection) -> bool {
     let client_version = env!("CARGO_PKG_VERSION");
 
     let deadline = get_time() + 5.0;
     let server_version = loop {
-        if let Some(config) = connection.db().global_config().iter().next() {
+        if let Some(config) = connection.db().public_global_config().iter().next() {
             break Some(config.version);
         }
         if get_time() > deadline {

--- a/client/src/login.rs
+++ b/client/src/login.rs
@@ -16,7 +16,8 @@ use macroquad::{
 };
 
 use solarance_beginnings::{server::bindings::DbConnection, stdb::connector::connect_to_spacetime};
-use spacetimedb_sdk::DbContext;
+use solarance_beginnings::server::bindings::*;
+use spacetimedb_sdk::{DbContext, Table};
 
 pub struct MenuAssets {
     pub rings: Vec<Texture2D>,
@@ -406,7 +407,13 @@ pub async fn loading_screen(token: Option<String>) -> Option<DbConnection> {
                 sleep(Duration::from_secs(1));
             }
 
-            // TODO - if the version of this binary and the version in GlobalConfig table is different, ask the user if they want to continue.
+            // Warn the player if this binary's version differs from the server's
+            // (stamped into `global_config` at init). They may continue or abort.
+            if let Some(cnx) = connection.as_ref() {
+                if !confirm_version_match(cnx).await {
+                    return None;
+                }
+            }
         } else if resources_loading.is_none() {
             // Only after the connection is alive do we actually load the resources.
             resources_loading = Some(start_coroutine(async move {
@@ -416,4 +423,101 @@ pub async fn loading_screen(token: Option<String>) -> Option<DbConnection> {
         }
     }
     return connection;
+}
+
+/// Compares this binary's version against the server's (written to the
+/// `global_config` table at init) and, on mismatch, asks the player whether to
+/// continue. Returns `true` to proceed into the game, `false` to abort to the menu.
+///
+/// The `global_config` row arrives via subscription shortly after connect, so we
+/// poll a few seconds for it; if it never shows we proceed rather than block the
+/// player on a check we can't complete.
+async fn confirm_version_match(connection: &DbConnection) -> bool {
+    let client_version = env!("CARGO_PKG_VERSION");
+
+    let deadline = get_time() + 5.0;
+    let server_version = loop {
+        if let Some(config) = connection.db().global_config().iter().next() {
+            break Some(config.version);
+        }
+        if get_time() > deadline {
+            break None;
+        }
+        draw_login_screen_background();
+        next_frame().await;
+    };
+
+    let Some(server_version) = server_version else {
+        warn!("Could not read server version from global_config within timeout; skipping version check.");
+        return true;
+    };
+
+    if server_version == client_version {
+        return true;
+    }
+
+    warn!(
+        "Version mismatch: client v{}, server v{}. Prompting player.",
+        client_version, server_version
+    );
+    show_version_mismatch_modal(client_version, &server_version).await
+}
+
+/// Modal shown when the client and server versions differ. Returns `true` if the
+/// player chooses to continue anyway, `false` to quit back to the menu.
+async fn show_version_mismatch_modal(client_version: &str, server_version: &str) -> bool {
+    let mut choice: Option<bool> = None;
+    loop {
+        draw_login_screen_background();
+
+        egui_macroquad::ui(|egui_ctx| {
+            egui::Window::new("Version Mismatch")
+                .title_bar(false)
+                .resizable(false)
+                .collapsible(false)
+                .movable(false)
+                .anchor(Align2::CENTER_CENTER, egui::Vec2::new(0.0, 0.0))
+                .frame(
+                    Frame::group(&egui_ctx.style())
+                        .fill(Color32::from_rgba_unmultiplied(15, 15, 15, 245))
+                        .shadow(Shadow::NONE),
+                )
+                .show(egui_ctx, |ui| {
+                    ui.vertical_centered(|ui| {
+                        ui.heading(
+                            RichText::new("Version Mismatch")
+                                .size(32.0)
+                                .color(Color32::from_rgb(255, 200, 0)),
+                        );
+                        ui.separator();
+                        ui.label(format!(
+                            "This client is v{client_version}, but the server is running v{server_version}."
+                        ));
+                        ui.label(
+                            "Playing on a mismatched version may cause errors or unexpected behavior.",
+                        );
+                        ui.separator();
+                        if ui
+                            .button(RichText::new("    Continue anyway    ").size(24.0))
+                            .clicked()
+                        {
+                            choice = Some(true);
+                        }
+                        if ui
+                            .button(RichText::new("    Quit to menu    ").size(24.0))
+                            .clicked()
+                        {
+                            choice = Some(false);
+                        }
+                    });
+                });
+        });
+
+        egui_macroquad::draw();
+        next_frame().await;
+
+        if let Some(c) = choice {
+            return c;
+        }
+    }
 }

--- a/client/src/stdb/connector/subscriptions.rs
+++ b/client/src/stdb/connector/subscriptions.rs
@@ -114,9 +114,9 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
             "SELECT * FROM my_direct_server_messages",
             "SELECT * FROM faction",
             "SELECT * FROM faction_standing",
-            // Public game config; the client reads `version` for the login-time
-            // version-mismatch check (see login.rs `confirm_version_match`).
-            "SELECT * FROM global_config",
+            // Anonymous view over GlobalConfig (3 public columns only); the client
+            // reads `version` for the login-time version-mismatch check (login.rs).
+            "SELECT * FROM public_global_config",
             "SELECT * FROM item_definition",
             cargo_crate.as_str(),
             "SELECT * FROM jump_gate",

--- a/client/src/stdb/connector/subscriptions.rs
+++ b/client/src/stdb/connector/subscriptions.rs
@@ -114,6 +114,9 @@ pub(super) fn subscribe_to_tables(ctx: &DbConnection) {
             "SELECT * FROM my_direct_server_messages",
             "SELECT * FROM faction",
             "SELECT * FROM faction_standing",
+            // Public game config; the client reads `version` for the login-time
+            // version-mismatch check (see login.rs `confirm_version_match`).
+            "SELECT * FROM global_config",
             "SELECT * FROM item_definition",
             cargo_crate.as_str(),
             "SELECT * FROM jump_gate",

--- a/docs/adr/0004-never-publish-to-maincloud-without-confirmation.md
+++ b/docs/adr/0004-never-publish-to-maincloud-without-confirmation.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+date: 2026-07-21
+prompted-by: "operator directive"
+---
+
+# Never publish to maincloud without explicit operator confirmation
+
+## Context
+
+Maincloud (`maincloud.spacetimedb.com`) is the live, hosted database. `CLAUDE.md`
+currently names maincloud as the default publish location and the database dashboard's
+home. During active development we build and republish the module constantly — and the
+publish tasks make maincloud a single flag away from local (`task server:publish-mc`,
+`task server:publish-clear-mc`, `task server:delete-mc`). An accidental maincloud publish
+would push unreviewed schema/logic to live players; a maincloud `--clear-database` /
+`--delete-data` would destroy live state irrecoverably.
+
+The local server is already the `spacetime` default (`127.0.0.1:3000`, marked `***` in
+`spacetime server list`), so routine work has no reason to touch maincloud.
+
+## Decision
+
+All development publishing targets **local only**. No agent, script, or automation runs
+any maincloud command — `spacetime publish --server maincloud` (`publish-mc`,
+`publish-clear-mc`), `delete-mc`, or any maincloud data-clearing/delete — unless the
+operator **explicitly asks for that maincloud action in the moment and confirms it**.
+
+- Publishing to maincloud is never a default, a fallback, or a side effect of another task.
+- **Clearing or deleting maincloud data requires a second, explicit confirmation** on top of
+  the request — it is the highest-stakes action in this repo.
+- This scopes the "maincloud is the default publish location" guidance in `CLAUDE.md` to
+  *production release* only; during development the default is local, full stop.
+
+## Why this shape
+
+- **Rely on the `***` local default alone** — rejected. It only decides the *default*
+  server; `--server maincloud` overrides it trivially, so the default is a convenience, not
+  a guard.
+- **A settings `deny`/`ask` permission rule or a pre-publish hook** — viable and stronger
+  (hard enforcement the agent can't bypass). Not done here because the operator asked for a
+  documented policy + agent note; a deny-rule can be layered on later if hard enforcement is
+  wanted.
+- **This ADR + an agent memory** (chosen) — documents the rule for humans and binds the
+  agent's behavior across sessions, at zero tooling cost. Ceiling: it's a convention, not an
+  interlock; escalate to the deny-rule above if that ceiling is ever hit.
+
+## Consequences
+
+- The agent asks before any maincloud publish and asks again before any maincloud clear/delete.
+- `docs/RELEASING.md` and `CLAUDE.md` maincloud references are understood as
+  *release-time, operator-initiated* steps, not routine ones.
+- If stronger-than-convention enforcement is desired, add a `spacetime publish.*maincloud`
+  `deny`/`ask` rule to `.claude/settings.json` (see the `update-config` skill).

--- a/server/src/tables/global_config.rs
+++ b/server/src/tables/global_config.rs
@@ -1,8 +1,8 @@
-use spacetimedb::{table, Timestamp};
+use spacetimedb::{table, view, SpacetimeType, Timestamp, ViewContext};
 use spacetimedsl::*;
 
 #[dsl(plural_name = global_configurations, method(update = true))]
-#[table(accessor = global_config, public)]
+#[table(accessor = global_config)]
 pub struct GlobalConfig {
     #[primary_key]
     #[create_wrapper]
@@ -25,6 +25,36 @@ pub struct GlobalConfig {
 
     created_at: Timestamp,
     modified_at: Timestamp,
+}
+
+///////////////////////////////////////////////////////////
+// Views
+///////////////////////////////////////////////////////////
+
+/// Publicly-visible subset of [`GlobalConfig`], exposed to every client
+/// (including pre-auth) via an anonymous view. The table itself stays private;
+/// the sensitive-to-nobody-but-server tunables (cargo-crate physics, timestamps)
+/// are simply not projected. The client reads `version` for the login
+/// version-mismatch check (see client `login.rs` `confirm_version_match`).
+#[derive(SpacetimeType)]
+pub struct PublicGlobalConfig {
+    pub active_players: u32,
+    pub old_gods_defeated: u8,
+    pub version: String,
+}
+
+/// Anonymous (not per-caller) view over the single GlobalConfig row.
+#[view(accessor = public_global_config, public)]
+pub fn public_global_config(ctx: &ViewContext) -> Vec<PublicGlobalConfig> {
+    let dsl = spacetimedsl::read_only_dsl(ctx);
+    match dsl.get_global_config_by_id(GlobalConfigId::new(0)) {
+        Ok(config) => vec![PublicGlobalConfig {
+            active_players: config.active_players,
+            old_gods_defeated: config.old_gods_defeated,
+            version: config.version,
+        }],
+        Err(_) => Vec::new(),
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/server/src/tables/global_config.rs
+++ b/server/src/tables/global_config.rs
@@ -2,7 +2,7 @@ use spacetimedb::{table, Timestamp};
 use spacetimedsl::*;
 
 #[dsl(plural_name = global_configurations, method(update = true))]
-#[table(accessor = global_config)]
+#[table(accessor = global_config, public)]
 pub struct GlobalConfig {
     #[primary_key]
     #[create_wrapper]


### PR DESCRIPTION
Closes #199. Resolves the long-standing `login.rs:409` TODO.

## What

- **Backend:** `GlobalConfig` stays **private**. Add an anonymous (not per-caller) view `public_global_config` (`server/src/tables/global_config.rs`) projecting only three columns — `active_players`, `old_gods_defeated`, `version`. The private tunables (cargo-crate physics, timestamps) are never exposed.
- **Client:** subscribe to the view (`SELECT * FROM public_global_config`).
- **Client:** in `loading_screen`, after identity is verified, poll ~5s for the view row, read `version`, and compare against `env!("CARGO_PKG_VERSION")`.
  - **Match** → login proceeds unchanged.
  - **Mismatch** → a modal (reusing the login background) names both versions and offers **Continue anyway** / **Quit to menu**. Quit returns `None`, the same path as other connection failures.
  - **Unreadable within timeout** → logged, player proceeds (never blocked on a check we can't complete).

Also includes **ADR-0004** (`docs/adr/0004-…`): never publish to maincloud without explicit operator confirmation. It's bundled here because it came out of this PR's deploy caveat; happy to split it out if preferred.

## Deploy note

The new subscription requires the server republished with the view. The **local** module is already republished (`task server:publish` — clean migration: view created, `global_config` returned to private, no data loss). **Maincloud is intentionally not touched** (see ADR-0004).

## Verification

- Module builds; bindings regenerate (`task client:generate`) — the projection view (`Vec<PublicGlobalConfig>`) is accepted and generates a `public_global_config` view accessor + `PublicGlobalConfig { active_players, old_gods_defeated, version }` row type.
- `cargo check --manifest-path client/Cargo.toml` — compiles clean.
- Local migration: `Created view public_global_config` + `Changed access for table global_config (public → private)`.
- Full visual check of the modal requires two client builds with differing versions against one server (not run headless here).

Client bindings are gitignored (regenerated per-dev), so they're not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)