### PR TITLE
Upgrade SpacetimeDSL from v0.20.1 to v0.21.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,9 @@
       "folderPath": "solarance-beginnings-game\\client\\src\\module_bindings\\",
       "badge": "🙈"
     }
+  ],
+  "cSpell.words": [
+    "sobj",
+    "spacetimedb"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,8 +731,8 @@ spacetime logs <module-name>
 ## Imports
 
 ```rust
-use spacetimedsl::*;        // Always — pulls in DSL, dsl(), WriteContext, etc.
-use spacetimedb::*;         // For ReducerContext, ScheduleAt, etc.
+use crate::spacetimedsl::prelude::*;        // Always — pulls in DSL, dsl(), WriteContext, etc.
+use spacetimedb::*;                         // For ReducerContext, ScheduleAt, etc.
 ```
 
 ---

--- a/agents/tmp/views/server_src/lib.rs
+++ b/agents/tmp/views/server_src/lib.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 mod physics;
 

--- a/agents/tmp/views/server_src/reducers.rs
+++ b/agents/tmp/views/server_src/reducers.rs
@@ -1,7 +1,7 @@
 use log::info;
 use solarance_shared::physics::predict_movement;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{physics::*, sectors::observe_all_public_sectors, tables::*};
 

--- a/agents/tmp/views/server_src/sectors.rs
+++ b/agents/tmp/views/server_src/sectors.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::*;
 

--- a/agents/tmp/views/server_src/tables.rs
+++ b/agents/tmp/views/server_src/tables.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::physics;
 
@@ -23,7 +23,7 @@ impl VisitedStatus {
     }
 }
 
-#[dsl(plural_name = ship_configs, method(update = false, delete = true))]
+#[spacetimedsl::dsl(plural_name = ship_configs, method(update = false, delete = true))]
 #[table(accessor = ship_config, public)]
 pub struct ShipConfig {
     #[primary_key]
@@ -36,7 +36,7 @@ pub struct ShipConfig {
     max_angular_acceleration: f32, // radians per second²
 }
 
-#[dsl(plural_name = space_ships, method(update = true, delete = true))]
+#[spacetimedsl::dsl(plural_name = space_ships, method(update = true, delete = true))]
 #[table(accessor = space_ship)]
 pub struct SpaceShip {
     #[primary_key]
@@ -63,7 +63,7 @@ pub struct SpaceShip {
     pub last_fired: spacetimedb::Timestamp,
 }
 
-#[dsl(plural_name = bullets, method(update = true, delete = true))]
+#[spacetimedsl::dsl(plural_name = bullets, method(update = true, delete = true))]
 #[table(accessor = bullet)]
 pub struct Bullet {
     #[primary_key]
@@ -87,7 +87,7 @@ pub struct Bullet {
     created_at: spacetimedb::Timestamp,
 }
 
-#[dsl(plural_name = systems, method(update = false, delete = true))]
+#[spacetimedsl::dsl(plural_name = systems, method(update = false, delete = true))]
 #[table(accessor = system)]
 pub struct System {
     #[primary_key]
@@ -97,7 +97,7 @@ pub struct System {
     name: String,
 }
 
-#[dsl(plural_name = sectors, method(update = true, delete = true), unique_index(name = position))]
+#[spacetimedsl::dsl(plural_name = sectors, method(update = true, delete = true), unique_index(name = position))]
 #[table(accessor = sector, index(accessor = position, btree(columns=[x,y])))]
 pub struct Sector {
     #[primary_key]
@@ -117,7 +117,7 @@ pub struct Sector {
 }
 
 /// Tracks where a player's ship is currently located.
-#[dsl(plural_name = player_states, method(update = true, delete = true))]
+#[spacetimedsl::dsl(plural_name = player_states, method(update = true, delete = true))]
 #[table(accessor = player_state)]
 pub struct PlayerState {
     #[primary_key]
@@ -136,7 +136,7 @@ pub struct PlayerState {
 }
 
 /// Private relationship table: Who has visited which system.
-#[dsl(plural_name = visited_systems, method(update = true, delete = false))]
+#[spacetimedsl::dsl(plural_name = visited_systems, method(update = true, delete = false))]
 #[table(accessor = visited_system)]
 pub struct VisitedSystem {
     #[primary_key]
@@ -150,7 +150,7 @@ pub struct VisitedSystem {
 }
 
 /// Private relationship table: Who has visited which specific sector.
-#[dsl(plural_name = visited_sectors, method(update = true, delete = false))]
+#[spacetimedsl::dsl(plural_name = visited_sectors, method(update = true, delete = false))]
 #[table(accessor = visited_sector)]
 pub struct VisitedSector {
     #[primary_key]
@@ -172,7 +172,7 @@ pub enum EventType {
 }
 
 /// A short-lived event used to broadcast visual effects to players in a sector.
-#[dsl(plural_name = damage_events, method(update = true, delete = false))]
+#[spacetimedsl::dsl(plural_name = damage_events, method(update = true, delete = false))]
 #[table(accessor = damage_event, public, event)]
 pub struct DamageEvent {
     #[primary_key]

--- a/agents/tmp/views/server_src/views.rs
+++ b/agents/tmp/views/server_src/views.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::*;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 spacetimedb = { version = "2.6.0" }
-spacetimedsl = "0.20.1"
+spacetimedsl = "0.21.1"
 log = "0.4"
 glam = "0.30.2"
 solarance-shared = { path = "../solarance-shared", features = ["server"] }

--- a/server/src/admin/cargo.rs
+++ b/server/src/admin/cargo.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use log::info;
 use spacetimedb::{Identity, ReducerContext};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::ships::cargo::attempt_to_load_cargo_into_ship;
 use crate::tables::items::*;

--- a/server/src/admin/cargo.rs
+++ b/server/src/admin/cargo.rs
@@ -7,7 +7,6 @@ use crate::spacetimedsl::prelude::*;
 use crate::logic::ships::cargo::attempt_to_load_cargo_into_ship;
 use crate::tables::items::*;
 use crate::tables::players::{get_player_ship_and_sobj, PlayerId};
-use crate::tables::ships::*;
 use crate::utility::try_server_only;
 
 /// Admin/seed reducer for M1 spike testing: spawn `quantity` units of

--- a/server/src/admin/construction.rs
+++ b/server/src/admin/construction.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::stations::contribution::{create_construction_site, reset_construction_site};
 use crate::logic::stations::*;

--- a/server/src/admin/creation.rs
+++ b/server/src/admin/creation.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 
 use solarance_shared::Vec2;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::stellarobjects::stellar_object_creation::create_sobj;
 use crate::tables::{

--- a/server/src/admin/messages.rs
+++ b/server/src/admin/messages.rs
@@ -10,7 +10,7 @@
 //! - Server is the implicit sender on every DSM, so no sender field is passed.
 
 use spacetimedb::{Identity, ReducerContext};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     tables::{

--- a/server/src/definitions/factions.rs
+++ b/server/src/definitions/factions.rs
@@ -1,6 +1,6 @@
 use log::info;
 
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::factions::*;
 

--- a/server/src/definitions/galaxy.rs
+++ b/server/src/definitions/galaxy.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use solarance_shared::Vec2;
 

--- a/server/src/definitions/item_types.rs
+++ b/server/src/definitions/item_types.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::PI;
 
 use log::info;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{combat::*, items::*};
 

--- a/server/src/definitions/mod.rs
+++ b/server/src/definitions/mod.rs
@@ -1,5 +1,5 @@
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 pub mod factions;
 pub mod galaxy;

--- a/server/src/definitions/ship_types.rs
+++ b/server/src/definitions/ship_types.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::PI;
 
 use log::info;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::ships::*;
 

--- a/server/src/definitions/station_module_types.rs
+++ b/server/src/definitions/station_module_types.rs
@@ -1,7 +1,7 @@
 use std::u8;
 
 use log::info;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     definitions::item_types::*,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -8,3 +8,5 @@ pub mod tables;
 pub mod utility;
 
 pub mod lifecycle;
+
+::spacetimedsl::spacetimedsl!();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,4 +1,3 @@
-use spacetimedsl::*;
 use tables::*;
 
 pub mod admin;

--- a/server/src/lifecycle/client_connected.rs
+++ b/server/src/lifecycle/client_connected.rs
@@ -2,7 +2,7 @@ use spacetimedb::*;
 use crate::spacetimedsl::prelude::*;
 
 use crate::logic::players::welcome_back::send_welcome_back_message;
-use crate::tables::{global_config::*, players::*};
+use crate::tables::players::*;
 
 #[spacetimedb::reducer(client_connected)]
 pub fn identity_connected(ctx: &ReducerContext) -> Result<(), String> {

--- a/server/src/lifecycle/client_connected.rs
+++ b/server/src/lifecycle/client_connected.rs
@@ -7,7 +7,7 @@ use crate::tables::players::*;
 #[spacetimedb::reducer(client_connected)]
 pub fn identity_connected(ctx: &ReducerContext) -> Result<(), String> {
     let dsl = dsl(ctx);
-    // Called everytime a new client connects
+    // Called every time a new client connects
 
     // TODO: When someone logs in set their player to online
 

--- a/server/src/lifecycle/client_connected.rs
+++ b/server/src/lifecycle/client_connected.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::players::welcome_back::send_welcome_back_message;
 use crate::tables::{global_config::*, players::*};

--- a/server/src/lifecycle/client_disconnected.rs
+++ b/server/src/lifecycle/client_disconnected.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{global_config::*, players::*};
 

--- a/server/src/lifecycle/client_disconnected.rs
+++ b/server/src/lifecycle/client_disconnected.rs
@@ -6,10 +6,10 @@ use crate::tables::players::*;
 #[spacetimedb::reducer(client_disconnected)]
 pub fn identity_disconnected(ctx: &ReducerContext) -> Result<(), String> {
     let dsl = dsl(ctx);
-    // Called everytime a client disconnects
+    // Called every time a client disconnects
 
     if let Ok(_player) = dsl.get_player_by_id(PlayerId::new(ctx.sender())) {
-        // Remove unneccessary timers and etc.
+        // Remove unnecessary timers and etc.
     }
 
     if let Some(mut config) = dsl.get_all_global_configurations().next() {

--- a/server/src/lifecycle/client_disconnected.rs
+++ b/server/src/lifecycle/client_disconnected.rs
@@ -1,7 +1,7 @@
 use spacetimedb::*;
 use crate::spacetimedsl::prelude::*;
 
-use crate::tables::{global_config::*, players::*};
+use crate::tables::players::*;
 
 #[spacetimedb::reducer(client_disconnected)]
 pub fn identity_disconnected(ctx: &ReducerContext) -> Result<(), String> {

--- a/server/src/lifecycle/init.rs
+++ b/server/src/lifecycle/init.rs
@@ -1,5 +1,5 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{definitions, tables::global_config::*};
 

--- a/server/src/lifecycle/timers.rs
+++ b/server/src/lifecycle/timers.rs
@@ -14,7 +14,7 @@ Rough draft of timings/tiers:
 use std::time::Duration;
 
 use log::info;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::{cargo_crates::*, factions::*, sectors::*},

--- a/server/src/logic/cargo_crates.rs
+++ b/server/src/logic/cargo_crates.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::add_cargo_timer::*,
@@ -54,7 +54,7 @@ pub fn attempt_to_pickup_cargo_crate<T: spacetimedsl::WriteContext>(
 
 /// Periodic sweeper that removes expired cargo crates. Replaces the per-crate
 /// despawn check that used to ride on the (now-removed) 20 Hz transform tick.
-#[dsl(plural_name = cargo_crate_despawn_sweeper_timers, method(update = false))]
+#[spacetimedsl::dsl(plural_name = cargo_crate_despawn_sweeper_timers, method(update = false))]
 #[spacetimedb::table(
     accessor = cargo_crate_despawn_sweeper_timer,
     scheduled(cargo_crate_despawn_sweeper)

--- a/server/src/logic/cargo_crates.rs
+++ b/server/src/logic/cargo_crates.rs
@@ -4,7 +4,7 @@ use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::add_cargo_timer::*,
-    tables::{items::*, ships::*, stellarobjects::*},
+    tables::{items::*, ships::*},
     utility::try_server_only,
 };
 

--- a/server/src/logic/chat_messages.rs
+++ b/server/src/logic/chat_messages.rs
@@ -6,7 +6,7 @@
 
 use log::info;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{
     messages::{

--- a/server/src/logic/chat_messages.rs
+++ b/server/src/logic/chat_messages.rs
@@ -14,8 +14,7 @@ use crate::tables::{
         post_star_system_channel, MessageSender,
     },
     players::*,
-    sectors::{SectorId, *},
-    ships::*,
+    sectors::SectorId,
 };
 
 /// Send a message to the **Galaxy** channel — visible to every logged-in player.

--- a/server/src/logic/combat/actions.rs
+++ b/server/src/logic/combat/actions.rs
@@ -1,5 +1,5 @@
 use log::info;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::{

--- a/server/src/logic/combat/visual_effects.rs
+++ b/server/src/logic/combat/visual_effects.rs
@@ -1,10 +1,10 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::stellarobjects::movement::get_sobj_pose;
 use crate::tables::{combat::*, items::*, sectors::SectorId, ships::*, stellarobjects::*};
 
-#[dsl(plural_name = visual_effect_timers,
+#[spacetimedsl::dsl(plural_name = visual_effect_timers,
     method(update = false, delete = true)
 )]
 #[spacetimedb::table(accessor = visual_effect_timer, scheduled(cleanup_visual_effect))]

--- a/server/src/logic/factions/mod.rs
+++ b/server/src/logic/factions/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use log::info;
 use spacetimedb::{ReducerContext, Timestamp};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     tables::{factions::*, stations::*},
@@ -13,7 +13,7 @@ use crate::{
 /// Timers
 
 /// Timer for periodic faction station checks - runs every 4 hours
-#[dsl(plural_name = faction_station_check_timers, method(update = true))]
+#[spacetimedsl::dsl(plural_name = faction_station_check_timers, method(update = true))]
 #[spacetimedb::table(
     accessor = faction_station_check_timer,
     scheduled(faction_station_check_timer_reducer)
@@ -35,7 +35,7 @@ pub struct FactionStationCheckTimer {
 }
 
 /// Overall faction management timer - runs every 12 hours to maintain faction timers
-#[dsl(plural_name = faction_management_timers, method(update = true))]
+#[spacetimedsl::dsl(plural_name = faction_management_timers, method(update = true))]
 #[spacetimedb::table(accessor = faction_management_timer, scheduled(faction_management_timer_reducer))]
 pub struct FactionManagementTimer {
     #[primary_key]

--- a/server/src/logic/players/registration.rs
+++ b/server/src/logic/players/registration.rs
@@ -1,5 +1,5 @@
 use spacetimedb::{Identity, ReducerContext, log};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::definitions::factions::FACTION_FACTIONLESS;
 use crate::tables::{

--- a/server/src/logic/players/registration.rs
+++ b/server/src/logic/players/registration.rs
@@ -7,7 +7,6 @@ use crate::tables::{
     messages::{post_faction_channel, MessageSender},
 };
 
-use crate::players::*;
 use crate::tables::players::{CreatePlayer, PlayerId};
 
 //////////////////////////////////////////////////////////////

--- a/server/src/logic/players/welcome_back.rs
+++ b/server/src/logic/players/welcome_back.rs
@@ -31,11 +31,7 @@
 use crate::spacetimedsl::prelude::*;
 use spacetimedb::Timestamp;
 
-// Glob-import the table modules whose generated DSL extension traits we call —
-// the per-table `Get*` traits must be in scope, not just the row/ID types.
-use crate::tables::{
-    items::*, messages::send_direct_server_info, players::Player, sectors::GetSectorRowOptionById, ships::*, stations::*
-};
+use crate::tables::{items::ItemDefinitionId, messages::send_direct_server_info, players::Player};
 
 /// Compose and deliver the welcome-back `DirectServerMessage` for `player`.
 ///

--- a/server/src/logic/players/welcome_back.rs
+++ b/server/src/logic/players/welcome_back.rs
@@ -28,8 +28,8 @@
 //! `last_login` and treats it as the welcome-back. That's the message this
 //! function emits exactly once per connect.
 
+use crate::spacetimedsl::prelude::*;
 use spacetimedb::Timestamp;
-use spacetimedsl::*;
 
 // Glob-import the table modules whose generated DSL extension traits we call —
 // the per-table `Get*` traits must be in scope, not just the row/ID types.

--- a/server/src/logic/sectors/asteroid_fields.rs
+++ b/server/src/logic/sectors/asteroid_fields.rs
@@ -3,7 +3,7 @@ use std::f32::consts::PI;
 use solarance_shared::Vec2;
 use spacetimedb::rand::Rng;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     definitions::item_types::*,

--- a/server/src/logic/sectors/mod.rs
+++ b/server/src/logic/sectors/mod.rs
@@ -2,7 +2,7 @@ use log::warn;
 use spacetimedb::ReducerContext;
 use crate::spacetimedsl::prelude::*;
 
-use crate::{logic::sectors::asteroid_fields::*, tables::sectors::*, utility::try_server_only};
+use crate::{logic::sectors::asteroid_fields::*, utility::try_server_only};
 
 pub mod asteroid_fields;
 

--- a/server/src/logic/sectors/mod.rs
+++ b/server/src/logic/sectors/mod.rs
@@ -1,6 +1,6 @@
 use log::warn;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{logic::sectors::asteroid_fields::*, tables::sectors::*, utility::try_server_only};
 
@@ -10,7 +10,7 @@ pub mod asteroid_fields;
 /// Timers
 ///
 
-#[dsl(plural_name = sector_upkeep_timers, method(update = false))]
+#[spacetimedsl::dsl(plural_name = sector_upkeep_timers, method(update = false))]
 #[spacetimedb::table(accessor = sector_upkeep_timer, scheduled(sector_upkeep))]
 pub struct SectorUpkeepTimer {
     #[primary_key]

--- a/server/src/logic/ships/add_cargo_timer.rs
+++ b/server/src/logic/ships/add_cargo_timer.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::cargo::attempt_to_load_cargo_into_ship,
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Adds a cargo item to a ship's cargo after a delay. If there isn't room, it creates a cargo crate instead.
-#[dsl(plural_name = ship_add_cargo_timers, method(update = false))]
+#[spacetimedsl::dsl(plural_name = ship_add_cargo_timers, method(update = false))]
 #[spacetimedb::table(accessor = ship_add_cargo_timer, scheduled(ship_add_cargo_timer_reducer))]
 pub struct ShipAddCargoTimer {
     #[primary_key]

--- a/server/src/logic/ships/cargo.rs
+++ b/server/src/logic/ships/cargo.rs
@@ -5,7 +5,7 @@ use log::info;
 use solarance_shared::{MovementState, Vec2};
 use spacetimedb::rand::Rng;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::cargo_crates::attempt_to_pickup_cargo_crate;
 use crate::logic::stellarobjects::stellar_object_creation::create_sobj;

--- a/server/src/logic/ships/creation.rs
+++ b/server/src/logic/ships/creation.rs
@@ -1,7 +1,7 @@
 use log::info;
 use solarance_shared::Vec2;
 use spacetimedb::{Identity, ReducerContext};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     definitions::item_types::*,

--- a/server/src/logic/ships/lifecycle.rs
+++ b/server/src/logic/ships/lifecycle.rs
@@ -1,4 +1,4 @@
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{players::*, stellarobjects::*};
 

--- a/server/src/logic/ships/mining.rs
+++ b/server/src/logic/ships/mining.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use log::{info, warn};
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::add_cargo_timer::*,
@@ -16,7 +16,7 @@ use crate::{
 /// drift away while extraction continues.
 pub const MINING_RANGE: f32 = 300.0;
 
-#[dsl(plural_name = ship_mining_timers, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ship_mining_timers, method(update = true))]
 #[spacetimedb::table(accessor = ship_mining_timer, scheduled(ship_mining_timer_reducer))]
 pub struct ShipMiningTimer {
     #[primary_key]

--- a/server/src/logic/ships/mining.rs
+++ b/server/src/logic/ships/mining.rs
@@ -6,7 +6,7 @@ use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::add_cargo_timer::*,
-    tables::{asteroids::*, items::*, messages::*, players::*, ships::*, stellarobjects::*},
+    tables::{items::*, messages::*, players::*, ships::*, stellarobjects::*},
     utility::try_server_only,
 };
 

--- a/server/src/logic/ships/movement_controllers.rs
+++ b/server/src/logic/ships/movement_controllers.rs
@@ -1,5 +1,5 @@
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::stellarobjects::movement::write_ship_movement_snapshot,

--- a/server/src/logic/ships/station_interactions.rs
+++ b/server/src/logic/ships/station_interactions.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::{

--- a/server/src/logic/ships/station_interactions.rs
+++ b/server/src/logic/ships/station_interactions.rs
@@ -13,7 +13,6 @@ use crate::{
     tables::{
         jumpgates::*,
         players::{get_player_ship_and_sobj, PlayerId},
-        sectors::GetSectorRowOptionById,
         messages::{send_direct_server_warning, send_direct_server_info},
         ships::*,
         stations::*,

--- a/server/src/logic/ships/status.rs
+++ b/server/src/logic/ships/status.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{tables::ships::*, utility::try_server_only};
 
-#[dsl(plural_name = ship_status_timers, method(update = false))]
+#[spacetimedsl::dsl(plural_name = ship_status_timers, method(update = false))]
 #[spacetimedb::table(accessor = ship_status_timer, scheduled(ship_status_timer_reducer))]
 pub struct ShipStatusTimer {
     #[primary_key]

--- a/server/src/logic/ships/weapons.rs
+++ b/server/src/logic/ships/weapons.rs
@@ -6,7 +6,7 @@ use crate::spacetimedsl::prelude::*;
 use crate::{
     logic::combat::actions::*,
     tables::{
-        players::*, ships::*,
+        players::*,
         stellarobjects::*,
     },
 };

--- a/server/src/logic/ships/weapons.rs
+++ b/server/src/logic/ships/weapons.rs
@@ -1,7 +1,7 @@
 
 use log::info;
 use spacetimedb::{reducer, ReducerContext};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::combat::actions::*,

--- a/server/src/logic/stations/buy_and_sell.rs
+++ b/server/src/logic/stations/buy_and_sell.rs
@@ -3,6 +3,7 @@ use crate::{
     tables::{items::*, messages::*, ships::*, stations::*},
     utility::is_server_or_ship_owner,
 };
+use crate::spacetimedsl::prelude::*;
 use spacetimedb::{log::info, ReducerContext};
 
 ///////////////////////////////////////////////////////////

--- a/server/src/logic/stations/buy_and_sell.rs
+++ b/server/src/logic/stations/buy_and_sell.rs
@@ -1,8 +1,7 @@
 use crate::{
     logic::ships::cargo::{attempt_to_load_cargo_into_ship, remove_cargo_from_ship},
-    tables::{items::*, messages::*, players::*, ships::*, stations::*},
+    tables::{items::*, messages::*, ships::*, stations::*},
     utility::is_server_or_ship_owner,
-    *,
 };
 use spacetimedb::{log::info, ReducerContext};
 

--- a/server/src/logic/stations/contribution.rs
+++ b/server/src/logic/stations/contribution.rs
@@ -14,7 +14,6 @@ use crate::{
         },
         players::*,
         sectors::Sector,
-        ships::*,
         stations::*,
         stellarobjects::StellarObject,
     },

--- a/server/src/logic/stations/contribution.rs
+++ b/server/src/logic/stations/contribution.rs
@@ -1,5 +1,5 @@
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     logic::ships::cargo::remove_cargo_from_ship,

--- a/server/src/logic/stations/mod.rs
+++ b/server/src/logic/stations/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 use std::time::Duration;
 
 pub mod buy_and_sell;

--- a/server/src/logic/stations/module_types/manufacturing.rs
+++ b/server/src/logic/stations/module_types/manufacturing.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::definitions::item_types::*;
 use crate::tables::economy::ResourceAmount;
@@ -8,7 +8,7 @@ use crate::tables::items::*;
 use crate::tables::stations::*;
 
 /// Defines a recipe that a manufacturing module can use.
-#[dsl(plural_name = production_recipe_definitions, method(update = false))]
+#[spacetimedsl::dsl(plural_name = production_recipe_definitions, method(update = false))]
 #[table(accessor = production_recipe_definition, public)]
 pub struct ProductionRecipeDefinition {
     #[primary_key]
@@ -33,7 +33,7 @@ pub struct ProductionRecipeDefinition {
 }
 
 /// Data for a generic manufacturing module instance (Factory, Assembler, Fabricator).
-#[dsl(plural_name = manufacturing_modules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = manufacturing_modules, method(update = true))]
 #[table(accessor = manufacturing_module, public)]
 pub struct Manufacturing {
     #[primary_key]

--- a/server/src/logic/stations/module_types/refineries.rs
+++ b/server/src/logic/stations/module_types/refineries.rs
@@ -1,13 +1,13 @@
 use log::info;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::definitions::station_module_types::*;
 use crate::tables::items::*;
 use crate::tables::stations::*;
 
 /// An instance of a refinery module
-#[dsl(plural_name = refinery_modules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = refinery_modules, method(update = true))]
 #[table(accessor = refinery_module, public)]
 pub struct Refinery {
     #[primary_key]

--- a/server/src/logic/stations/module_types/solar_arrays.rs
+++ b/server/src/logic/stations/module_types/solar_arrays.rs
@@ -1,5 +1,5 @@
 use spacetimedb::table;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::sectors::*;
 use crate::tables::stations::*;
@@ -19,7 +19,7 @@ pub const MODULE_SOLAR_ARRAY_MEDIUM: u32 = 7_001;
 pub const MODULE_SOLAR_ARRAY_LARGE: u32 = 7_002;
 pub const MODULE_SOLAR_ARRAY_INDUSTRIAL: u32 = 7_003;
 
-#[dsl(plural_name = solar_array_modules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = solar_array_modules, method(update = true))]
 #[table(accessor = solar_array_module, public)]
 pub struct SolarArray {
     #[primary_key]

--- a/server/src/logic/stations/module_types/trading_port.rs
+++ b/server/src/logic/stations/module_types/trading_port.rs
@@ -1,12 +1,12 @@
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::definitions::item_types::*;
 use crate::definitions::station_module_types::*;
 use crate::tables::items::*;
 use crate::tables::stations::*;
 
-#[dsl(plural_name = trading_port_modules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = trading_port_modules, method(update = true))]
 #[table(accessor = trading_port_module, public)]
 pub struct TradingPort {
     #[primary_key]
@@ -20,7 +20,7 @@ pub struct TradingPort {
 
 /// Represents items the Trading Port module is actively buying or selling.
 /// This is distinct from general market orders placed by players at a station.
-#[dsl(plural_name = trading_port_listings, method(update = true))]
+#[spacetimedsl::dsl(plural_name = trading_port_listings, method(update = true))]
 #[table(accessor = trading_port_listing, public)]
 pub struct TradingPortListing {
     #[primary_key]

--- a/server/src/logic/stations/production.rs
+++ b/server/src/logic/stations/production.rs
@@ -1,5 +1,4 @@
-use crate::*;
-use spacetimedb::{log::info, *};
+use spacetimedb::log::info;
 
 use super::*;
 

--- a/server/src/logic/stations/production.rs
+++ b/server/src/logic/stations/production.rs
@@ -3,7 +3,7 @@ use spacetimedb::{log::info, *};
 
 use super::*;
 
-#[dsl(plural_name = station_production_schedules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_production_schedules, method(update = true))]
 #[spacetimedb::table(accessor = station_production_schedule, scheduled(station_production_schedule_reducer))]
 pub struct StationProductionSchedule {
     #[primary_key]

--- a/server/src/logic/stations/status.rs
+++ b/server/src/logic/stations/status.rs
@@ -1,8 +1,8 @@
 use crate::tables::stations::StationId;
 use spacetimedb::*;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
-#[dsl(plural_name = station_status_schedules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_status_schedules, method(update = true))]
 #[spacetimedb::table(accessor = station_status_schedule, scheduled(station_status_schedule_reducer))]
 pub struct StationStatusSchedule {
     #[primary_key]

--- a/server/src/logic/stellarobjects/movement.rs
+++ b/server/src/logic/stellarobjects/movement.rs
@@ -12,7 +12,7 @@
 //! `CargoCrate.movement`. The Phase 6 audit confirms no caller bypasses them.
 
 use solarance_shared::{predict_movement, MovementState, Vec2};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{
     asteroids::*, global_config::*, items::*, jumpgates::*, sectors::*, ships::*, stations::*,

--- a/server/src/logic/stellarobjects/movement.rs
+++ b/server/src/logic/stellarobjects/movement.rs
@@ -15,7 +15,7 @@ use solarance_shared::{predict_movement, MovementState, Vec2};
 use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{
-    asteroids::*, global_config::*, items::*, jumpgates::*, sectors::*, ships::*, stations::*,
+    global_config::*, items::*, sectors::*, ships::*,
     stellarobjects::*,
 };
 

--- a/server/src/logic/stellarobjects/stellar_object_creation.rs
+++ b/server/src/logic/stellarobjects/stellar_object_creation.rs
@@ -10,7 +10,7 @@ use crate::tables::sectors::SectorId;
 use crate::tables::stellarobjects::*;
 use crate::utility::try_server_only;
 use spacetimedb::ReducerContext;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 /// Creates a stellar object with no position payload. The caller is
 /// responsible for populating the per-kind position field on the

--- a/server/src/tables/asteroids.rs
+++ b/server/src/tables/asteroids.rs
@@ -1,12 +1,12 @@
 use log::info;
 use solarance_shared::Vec2;
 use spacetimedb::table;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::logic::stellarobjects::stellar_object_creation::create_sobj;
 use crate::tables::{items::ItemDefinitionId, sectors::SectorId, stellarobjects::*};
 
-#[dsl(plural_name = asteroids, method(update = true))]
+#[spacetimedsl::dsl(plural_name = asteroids, method(update = true))]
 #[table(accessor = asteroid, public)]
 pub struct Asteroid {
     #[primary_key]

--- a/server/src/tables/combat.rs
+++ b/server/src/tables/combat.rs
@@ -61,7 +61,7 @@ impl From<spacetimedsl::SpacetimeDSLError> for CombatError {
     }
 }
 
-#[dsl(plural_name = visual_effects, method(update = false))]
+#[spacetimedsl::dsl(plural_name = visual_effects, method(update = false))]
 #[table(accessor = visual_effect, public)]
 pub struct VisualEffect {
     #[primary_key]

--- a/server/src/tables/combat.rs
+++ b/server/src/tables/combat.rs
@@ -1,5 +1,4 @@
 use spacetimedb::{table, SpacetimeType, Timestamp};
-use spacetimedsl::*;
 
 use solarance_shared::Vec2;
 

--- a/server/src/tables/factions.rs
+++ b/server/src/tables/factions.rs
@@ -1,5 +1,5 @@
 use spacetimedb::{table, SpacetimeType};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{sectors::*, ships::*, stations::*};
 
@@ -19,7 +19,7 @@ pub enum FactionTier {
     Squad, // e.g., local corporation, pirate clan
 }
 
-#[dsl(plural_name = factions, method(update = true))]
+#[spacetimedsl::dsl(plural_name = factions, method(update = true))]
 #[table(accessor = faction, public)]
 pub struct Faction {
     #[primary_key]
@@ -53,7 +53,7 @@ pub struct Faction {
     // Other faction-specific data like relations, home sector, etc.
 }
 
-#[dsl(plural_name = faction_standings, method(update = true))]
+#[spacetimedsl::dsl(plural_name = faction_standings, method(update = true))]
 #[table(accessor = faction_standing, public)]
 pub struct FactionStanding {
     #[primary_key]
@@ -81,7 +81,7 @@ pub struct FactionStanding {
 
 // We are ignoring player-level faction standings at the moment.
 
-// #[dsl(plural_name = player_faction_standings, method(update = true))]
+// #[spacetimedsl::dsl(plural_name = player_faction_standings, method(update = true))]
 // #[table(accessor = player_faction_standing, public)]
 // pub struct PlayerFactionStanding {
 //     #[primary_key]

--- a/server/src/tables/global_config.rs
+++ b/server/src/tables/global_config.rs
@@ -1,7 +1,7 @@
 use spacetimedb::{table, Timestamp};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
-#[dsl(plural_name = global_configurations, method(update = true))]
+#[spacetimedsl::dsl(plural_name = global_configurations, method(update = true))]
 #[table(accessor = global_config)]
 pub struct GlobalConfig {
     #[primary_key]

--- a/server/src/tables/items.rs
+++ b/server/src/tables/items.rs
@@ -1,6 +1,5 @@
 use solarance_shared::MovementState;
 use spacetimedb::{table, SpacetimeType, Timestamp};
-use spacetimedsl::*;
 
 use crate::tables::{
     combat::{MissileType, WeaponType},

--- a/server/src/tables/items.rs
+++ b/server/src/tables/items.rs
@@ -117,7 +117,7 @@ pub enum ItemMetadata {
     Quality(u8),
 }
 
-#[dsl(plural_name = item_definitions, method(update = true))]
+#[spacetimedsl::dsl(plural_name = item_definitions, method(update = true))]
 #[table(accessor = item_definition, public)]
 pub struct ItemDefinition {
     #[primary_key]
@@ -147,7 +147,7 @@ pub struct ItemDefinition {
     pub gfx_key: Option<String>, // For items that have a visual representation
 }
 
-#[dsl(plural_name = cargo_crates, method(update = true))]
+#[spacetimedsl::dsl(plural_name = cargo_crates, method(update = true))]
 #[table(accessor = cargo_crate, public)]
 pub struct CargoCrate {
     #[primary_key]

--- a/server/src/tables/jumpgates.rs
+++ b/server/src/tables/jumpgates.rs
@@ -1,9 +1,9 @@
 use spacetimedb::table;
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use solarance_shared::Vec2;
 
-#[dsl(plural_name = jump_gates, method(update = true))]
+#[spacetimedsl::dsl(plural_name = jump_gates, method(update = true))]
 #[table(accessor = jump_gate, public)]
 pub struct JumpGate {
     #[primary_key]

--- a/server/src/tables/messages.rs
+++ b/server/src/tables/messages.rs
@@ -23,14 +23,8 @@
 use crate::spacetimedsl::prelude::*;
 use spacetimedb::{table, view, Identity, SpacetimeType, Timestamp, ViewContext};
 
-// Glob-import the per-table DSL extension traits the view bodies need
-// (`get_player_by_id`, `get_ships_by_player_id`, `get_sector_by_id`, …).
 use crate::tables::{
-    factions::FactionId,
-    players::{PlayerId, *},
-    sectors::{SectorId, *},
-    ships::*,
-    star_system::StarSystemId,
+    factions::FactionId, players::PlayerId, sectors::SectorId, star_system::StarSystemId,
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/src/tables/messages.rs
+++ b/server/src/tables/messages.rs
@@ -20,8 +20,8 @@
 //! no natural key, so it carries a constant indexed `galaxy_id` (always `0`)
 //! that the view filters on, plus an in-body "is the caller a player?" gate.
 
+use crate::spacetimedsl::prelude::*;
 use spacetimedb::{table, view, Identity, SpacetimeType, Timestamp, ViewContext};
-use spacetimedsl::*;
 
 // Glob-import the per-table DSL extension traits the view bodies need
 // (`get_player_by_id`, `get_ships_by_player_id`, `get_sector_by_id`, …).
@@ -71,7 +71,7 @@ pub enum MessageSeverity {
 /// **Public** table — readable by anyone connected (including not-logged-in
 /// and banned identities), and is the only message table safe to surface
 /// outside the game client (e.g. a website status page).
-#[dsl(plural_name = server_channel_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = server_channel_messages, method(update = false))]
 #[table(accessor = server_channel_message, public)]
 pub struct ServerChannelMessage {
     #[primary_key]
@@ -87,7 +87,7 @@ pub struct ServerChannelMessage {
 /// `galaxy_id` is a constant (`0`) indexed column whose only job is to keep
 /// the view legal under the "no full scan" rule — single-galaxy MVP, but the
 /// column is real domain shape so it survives the eventual multi-galaxy add.
-#[dsl(plural_name = galaxy_channel_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = galaxy_channel_messages, method(update = false))]
 #[table(accessor = galaxy_channel_message)]
 pub struct GalaxyChannelMessage {
     #[primary_key]
@@ -106,7 +106,7 @@ pub struct GalaxyChannelMessage {
 /// Scoped to one StarSystem. Audience: players whose Ship is in a Sector of
 /// that StarSystem. In MVP one StarSystem exists, so this is effectively
 /// galaxy-wide today; correctly scopes when system #2 ships.
-#[dsl(plural_name = star_system_channel_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = star_system_channel_messages, method(update = false))]
 #[table(accessor = star_system_channel_message)]
 pub struct StarSystemChannelMessage {
     #[primary_key]
@@ -125,7 +125,7 @@ pub struct StarSystemChannelMessage {
 }
 
 /// Scoped to one Sector. Audience: players whose Ship is in that Sector.
-#[dsl(plural_name = sector_channel_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = sector_channel_messages, method(update = false))]
 #[table(accessor = sector_channel_message)]
 pub struct SectorChannelMessage {
     #[primary_key]
@@ -144,7 +144,7 @@ pub struct SectorChannelMessage {
 }
 
 /// Scoped to one Faction. Audience: players of that Faction.
-#[dsl(plural_name = faction_channel_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = faction_channel_messages, method(update = false))]
 #[table(accessor = faction_channel_message)]
 pub struct FactionChannelMessage {
     #[primary_key]
@@ -173,7 +173,7 @@ pub struct FactionChannelMessage {
 /// **Read state is *not* stored here.** A message is "unread" if its
 /// `created_at` is later than the player's `last_login`; the client highlights
 /// those and clears the highlight when the player next sends a chat message.
-#[dsl(plural_name = direct_server_messages, method(update = false))]
+#[spacetimedsl::dsl(plural_name = direct_server_messages, method(update = false))]
 #[table(accessor = direct_server_message)]
 pub struct DirectServerMessage {
     #[primary_key]

--- a/server/src/tables/messages.rs
+++ b/server/src/tables/messages.rs
@@ -214,7 +214,7 @@ pub fn my_direct_server_messages(ctx: &ViewContext) -> Vec<DirectServerMessage> 
 /// Non-players (not-logged-in / banned) get `vec![]`.
 #[view(accessor = my_galaxy_chat, public)]
 pub fn my_galaxy_chat(ctx: &ViewContext) -> Vec<GalaxyChannelMessage> {
-    let dsl = spacetimedsl::read_only_dsl(ctx);
+    let dsl = read_only_dsl(ctx);
     if dsl.get_player_by_id(PlayerId::new(ctx.sender())).is_err() {
         return Vec::new();
     }
@@ -229,7 +229,7 @@ pub fn my_galaxy_chat(ctx: &ViewContext) -> Vec<GalaxyChannelMessage> {
 /// ship's sector). No ship → no view contents.
 #[view(accessor = my_star_system_chat, public)]
 pub fn my_star_system_chat(ctx: &ViewContext) -> Vec<StarSystemChannelMessage> {
-    let dsl = spacetimedsl::read_only_dsl(ctx);
+    let dsl = read_only_dsl(ctx);
     let ship = match dsl
         .get_ships_by_player_id(&PlayerId::new(ctx.sender()))
         .next()
@@ -252,7 +252,7 @@ pub fn my_star_system_chat(ctx: &ViewContext) -> Vec<StarSystemChannelMessage> {
 /// Sector chat for the caller's *current* Sector (derived via their ship).
 #[view(accessor = my_sector_chat, public)]
 pub fn my_sector_chat(ctx: &ViewContext) -> Vec<SectorChannelMessage> {
-    let dsl = spacetimedsl::read_only_dsl(ctx);
+    let dsl = read_only_dsl(ctx);
     let ship = match dsl
         .get_ships_by_player_id(&PlayerId::new(ctx.sender()))
         .next()
@@ -271,7 +271,7 @@ pub fn my_sector_chat(ctx: &ViewContext) -> Vec<SectorChannelMessage> {
 /// Faction chat for the caller's Faction.
 #[view(accessor = my_faction_chat, public)]
 pub fn my_faction_chat(ctx: &ViewContext) -> Vec<FactionChannelMessage> {
-    let dsl = spacetimedsl::read_only_dsl(ctx);
+    let dsl = read_only_dsl(ctx);
     let player = match dsl.get_player_by_id(PlayerId::new(ctx.sender())) {
         Ok(p) => p,
         Err(_) => return Vec::new(),

--- a/server/src/tables/players.rs
+++ b/server/src/tables/players.rs
@@ -1,11 +1,11 @@
 use spacetimedb::{table, Identity, Timestamp};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::tables::{factions::FactionId, ships::*};
 
 use super::stellarobjects::*;
 
-#[dsl(plural_name = players, method(update = true))]
+#[spacetimedsl::dsl(plural_name = players, method(update = true))]
 #[table(accessor = player, public)]
 pub struct Player {
     #[primary_key]

--- a/server/src/tables/sectors.rs
+++ b/server/src/tables/sectors.rs
@@ -1,13 +1,13 @@
 use solarance_shared::Vec2;
 use spacetimedb::{table, SpacetimeType};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{
     admin::creation::create_jumpgate_internal,
     tables::{factions::*, star_system::*},
 };
 
-#[dsl(plural_name = sectors, method(update = true))]
+#[spacetimedsl::dsl(plural_name = sectors, method(update = true))]
 #[table(accessor = sector, public)]
 pub struct Sector {
     #[primary_key] // NOT Auto-inc so it can be reloaded as-is
@@ -78,7 +78,7 @@ pub struct OreWeight {
     pub weight: u16,
 }
 
-#[dsl(plural_name = asteroid_sectors, method(update = false))]
+#[spacetimedsl::dsl(plural_name = asteroid_sectors, method(update = false))]
 #[table(accessor = asteroid_sector)]
 pub struct AsteroidSector {
     #[primary_key] // NOT Auto-inc so it can be reloaded as-is
@@ -98,7 +98,7 @@ pub struct AsteroidSector {
 
 /// Decorative in-sector nebula sprite (#107). Pure render flavor — no stellar
 /// object, no collision, no game mechanic. Ships fly straight through them.
-#[dsl(plural_name = sector_nebulae, method(update = false))]
+#[spacetimedsl::dsl(plural_name = sector_nebulae, method(update = false))]
 #[table(accessor = sector_nebula, public)]
 pub struct SectorNebula {
     #[primary_key]

--- a/server/src/tables/ships.rs
+++ b/server/src/tables/ships.rs
@@ -1,6 +1,6 @@
 use log::info;
 use spacetimedb::{table, Identity, SpacetimeType};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use solarance_shared::{MovementState, Vec2};
 
@@ -44,7 +44,7 @@ pub enum EquipmentSlotType {
     CargoExpansion,
 }
 
-#[dsl(plural_name = ship_type_definitions, method(update = true))] // One could argue that this should be false. idk atm - Karl
+#[spacetimedsl::dsl(plural_name = ship_type_definitions, method(update = true))] // One could argue that this should be false. idk atm - Karl
 #[table(accessor = ship_type_definition, public)]
 pub struct ShipTypeDefinition {
     #[primary_key] // NOT Auto-inc so it can be reloaded as-is
@@ -113,7 +113,7 @@ impl ShipTypeDefinition {
     }
 }
 
-#[dsl(plural_name = ship_statuses, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ship_statuses, method(update = true))]
 #[table(accessor = ship_status, public)]
 /// The status of a ship agnostic of where it is physically.
 pub struct ShipStatus {
@@ -177,7 +177,7 @@ impl ShipStatus {
     }
 }
 
-#[dsl(plural_name = ship_movement_controllers, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ship_movement_controllers, method(update = true))]
 #[table(accessor = ship_movement_controller, public)]
 /// Input-state mirror for a player's ship. The dead-reckoning rewrite
 /// narrowed this row's role: it only feeds the no-op early-return inside
@@ -195,7 +195,7 @@ pub struct ShipMovementController {
     pub right: bool,
 }
 
-#[dsl(plural_name = ships, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ships, method(update = true))]
 #[table(accessor = ship, public)]
 pub struct Ship {
     #[primary_key]
@@ -249,7 +249,7 @@ pub struct Ship {
     pub movement: MovementState,
 }
 
-#[dsl(plural_name = ship_cargo_items, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ship_cargo_items, method(update = true))]
 #[table(accessor = ship_cargo_item, public)]
 pub struct ShipCargoItem {
     #[primary_key]
@@ -273,7 +273,7 @@ pub struct ShipCargoItem {
                        //pub stack_size: u8, // TODO: Do we keep this value here to save query time?
 }
 
-#[dsl(plural_name = ship_equipment_slots, method(update = true))]
+#[spacetimedsl::dsl(plural_name = ship_equipment_slots, method(update = true))]
 #[table(accessor = ship_equipment_slot, public)]
 pub struct ShipEquipmentSlot {
     #[primary_key]

--- a/server/src/tables/star_system.rs
+++ b/server/src/tables/star_system.rs
@@ -1,5 +1,4 @@
 use spacetimedb::{table, SpacetimeType};
-use spacetimedsl::*;
 
 use solarance_shared::Vec2;
 

--- a/server/src/tables/star_system.rs
+++ b/server/src/tables/star_system.rs
@@ -32,7 +32,7 @@ pub enum StarSystemObjectKind {
     NebulaBelt,
 }
 
-#[dsl(plural_name = star_systems, method(update = true))] // Keeping it true in case we want to edit the galaxy
+#[spacetimedsl::dsl(plural_name = star_systems, method(update = true))] // Keeping it true in case we want to edit the galaxy
 #[table(accessor = star_system, public)]
 pub struct StarSystem {
     #[primary_key]
@@ -59,7 +59,7 @@ pub struct StarSystem {
     //pub discovered_by_faction_id: Option<u32>, // First faction to chart it
 }
 
-#[dsl(plural_name = star_system_objects, method(update = true))] // Keeping it true in case we want to edit the galaxy
+#[spacetimedsl::dsl(plural_name = star_system_objects, method(update = true))] // Keeping it true in case we want to edit the galaxy
 #[table(accessor = star_system_object, public)]
 pub struct StarSystemObject {
     #[primary_key]

--- a/server/src/tables/stations.rs
+++ b/server/src/tables/stations.rs
@@ -75,7 +75,7 @@ pub enum StationModuleSpecificType {
 /////////////////////////////////////
 // Tables
 
-#[dsl(plural_name = station_module_blueprints, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_module_blueprints, method(update = true))]
 #[table(accessor = station_module_blueprint, public)]
 pub struct StationModuleBlueprint {
     #[primary_key]
@@ -110,7 +110,7 @@ pub struct StationModuleBlueprint {
     pub operational_hp: u32,  // Max HP when fully built
 }
 
-#[dsl(plural_name = station_modules, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_modules, method(update = true))]
 #[table(accessor = station_module, public)]
 pub struct StationModule {
     #[primary_key]
@@ -138,7 +138,7 @@ pub struct StationModule {
     pub last_status_update_timestamp: Timestamp,
 }
 
-#[dsl(plural_name = stations_under_construction, method(update = true))]
+#[spacetimedsl::dsl(plural_name = stations_under_construction, method(update = true))]
 #[table(accessor = station_under_construction, public)]
 pub struct StationUnderConstruction {
     #[primary_key]
@@ -155,7 +155,7 @@ pub struct StationUnderConstruction {
 /// Together these rows define the "spec" — the pure progress engine compares
 /// this spec against the rows in `construction_contribution_log` to derive
 /// the percentage stored on `StationUnderConstruction`.
-#[dsl(plural_name = construction_requirements, method(update = true))]
+#[spacetimedsl::dsl(plural_name = construction_requirements, method(update = true))]
 #[table(accessor = construction_requirement, public)]
 pub struct ConstructionRequirement {
     #[primary_key]
@@ -181,7 +181,7 @@ pub struct ConstructionRequirement {
 
 /// Append-only log of every contribution event. Source of truth for both
 /// real-time progress recomputation and the welcome-back screen query (#82b).
-#[dsl(plural_name = construction_contribution_logs, method(update = false))]
+#[spacetimedsl::dsl(plural_name = construction_contribution_logs, method(update = false))]
 #[table(accessor = construction_contribution_log, public)]
 pub struct ConstructionContributionLog {
     #[primary_key]
@@ -213,7 +213,7 @@ pub struct ConstructionContributionLog {
     contributed_at: Timestamp,
 }
 
-#[dsl(plural_name = station_modules_under_construction, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_modules_under_construction, method(update = true))]
 #[table(accessor = station_module_under_construction, public)]
 pub struct StationModuleUnderConstruction {
     #[primary_key]
@@ -227,7 +227,7 @@ pub struct StationModuleUnderConstruction {
 }
 
 /// Stores items used for a module's operation or as temporary input/output buffers.
-#[dsl(plural_name = station_module_inventory_items, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_module_inventory_items, method(update = true))]
 #[table(accessor = station_module_inventory_item, public)]
 pub struct StationModuleInventoryItem {
     #[primary_key]
@@ -257,7 +257,7 @@ pub struct StationModuleInventoryItem {
     pub cached_price: u32,
 }
 
-#[dsl(plural_name = stations, method(update = true))]
+#[spacetimedsl::dsl(plural_name = stations, method(update = true))]
 #[table(accessor = station, public)]
 pub struct Station {
     #[primary_key]
@@ -305,7 +305,7 @@ pub struct Station {
     pub rotation: f32,
 }
 
-#[dsl(plural_name = station_statuses, method(update = true))]
+#[spacetimedsl::dsl(plural_name = station_statuses, method(update = true))]
 #[table(accessor = station_status, public)]
 pub struct StationStatus {
     #[primary_key]

--- a/server/src/tables/stations.rs
+++ b/server/src/tables/stations.rs
@@ -1,10 +1,9 @@
 use solarance_shared::Vec2;
 use spacetimedb::{table, Identity, SpacetimeType, Timestamp};
-use spacetimedsl::*;
+use crate::{sectors, stellarobjects, factions};
 
 use crate::tables::economy::ResourceAmount;
 use crate::tables::items::*;
-use crate::*;
 
 //////////////////////////////////
 // Enums

--- a/server/src/tables/stellarobjects.rs
+++ b/server/src/tables/stellarobjects.rs
@@ -1,5 +1,5 @@
 use spacetimedb::{table, SpacetimeType};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 /// What kind of stellar object it is. OBE with the advent of asteroid/ship/station tables?
 #[derive(SpacetimeType, Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
@@ -17,7 +17,7 @@ pub enum StellarObjectKinds {
 /// and sector — position/rotation live on the per-kind tables
 /// (`Ship.movement`, `CargoCrate.movement`, `Asteroid.position`,
 /// `Station.position`/`rotation`, `JumpGate.position`/`rotation`).
-#[dsl(plural_name = stellar_objects, method(update = true))]
+#[spacetimedsl::dsl(plural_name = stellar_objects, method(update = true))]
 #[table(accessor = stellar_object, public)]
 pub struct StellarObject {
     #[primary_key]

--- a/server/src/utility.rs
+++ b/server/src/utility.rs
@@ -1,5 +1,5 @@
 use log::{warn, info};
-use spacetimedsl::*;
+use crate::spacetimedsl::prelude::*;
 
 use crate::{ships::*, stellarobjects::*};
 


### PR DESCRIPTION
This update gets rid of all the traits (e.g. Create{Table}Row, Update{Table}Row, Delete{Table}Row, Get{Table}Rows, etc.) which were previously required to import when wanting to use a DSL method in a module. See https://github.com/tamaro-skaljic/SpacetimeDSL/releases/tag/v0.21.0

Migration effort was minimal (20 minutes), mostly regex replaces, every other problem was found through compilation errors.

Creating commits with the precise changes took longer than the actual work (review commit by commit to see changes grouped by a short description).

I thought I had to do more, but because you use glob imports all over the place, it was easy.

I think you used glob imports because it was annoying to import all these traits from SpacetimeDSL? Now you don't need to do anymore!

No AI was used for this pull request.